### PR TITLE
Add secret to satisfy Connect's session middleware

### DIFF
--- a/Apps/HelloWorld/hello.js
+++ b/Apps/HelloWorld/hello.js
@@ -14,7 +14,7 @@ process.chdir(cwd);
 
 var fs = require('fs'),http = require('http');
 var express = require('express'),connect = require('connect');
-var app = express.createServer(connect.bodyDecoder(), connect.cookieDecoder(), connect.session());
+var app = express.createServer(connect.bodyDecoder(), connect.cookieDecoder(), connect.session({secret : "locker"}));
 
 app.set('views', __dirname);
 

--- a/Apps/MergedContacts/contacts.js
+++ b/Apps/MergedContacts/contacts.js
@@ -8,7 +8,7 @@ var fs = require('fs'),
 var app = express.createServer(
                 connect.bodyDecoder(),
                 connect.cookieDecoder(),
-                connect.session()
+                connect.session({secret : "locker"})
             );
 
 function compareContacts(a, b) {

--- a/Connectors/AmazonHistory/server.js
+++ b/Connectors/AmazonHistory/server.js
@@ -8,7 +8,7 @@ var fs = require('fs'),
 var app = express.createServer(
                 connect.bodyDecoder(),
                 connect.cookieDecoder(),
-                connect.session()
+                connect.session({secret : "locker"})
             );
 
 

--- a/Connectors/ChromeHistory/client.js
+++ b/Connectors/ChromeHistory/client.js
@@ -8,7 +8,7 @@ connect = require('connect'),
 app = express.createServer(
     connect.bodyDecoder(),
     connect.cookieDecoder(),
-    connect.session());
+    connect.session({secret : "locker"}));
 
 app.post('/urls',
     function(req, res) {

--- a/Connectors/Facebook/client.js
+++ b/Connectors/Facebook/client.js
@@ -18,7 +18,7 @@ var fs = require('fs'),
     app = express.createServer(
                     connect.bodyDecoder(),
                     connect.cookieDecoder(),
-                    connect.session()),
+                    connect.session({secret : "locker"})),
     lfs = require('../../Common/node/lfs.js');
 
 var wwwdude = require('wwwdude'),

--- a/Connectors/Flickr/client.js
+++ b/Connectors/Flickr/client.js
@@ -16,7 +16,7 @@ var crypto = require('crypto'),
     app = express.createServer(
             connect.bodyDecoder(),
             connect.cookieDecoder(),
-            connect.session());
+            connect.session({secret : "locker"}));
 
 var lfs = require('../common/node/lfs');
 

--- a/Connectors/IMAP/demo.js
+++ b/Connectors/IMAP/demo.js
@@ -6,7 +6,7 @@ var port = 3005;
 
 var fs = require('fs'),http = require('http');
 var express = require('express'),connect = require('connect');
-var app = express.createServer(connect.bodyDecoder(), connect.cookieDecoder(), connect.session());
+var app = express.createServer(connect.bodyDecoder(), connect.cookieDecoder(), connect.session({secret : "locker"}));
 var lfs = require('../../Common/node/lfs.js');
 
 

--- a/Connectors/Twitter/client.js
+++ b/Connectors/Twitter/client.js
@@ -18,7 +18,7 @@ var twitterClient = require('twitter-js')(consumerKey, consumerSecret, 'http://1
     app = express.createServer(
         connect.bodyDecoder(),
         connect.cookieDecoder(),
-        connect.session()
+        connect.session({secret : "locker"})
     );
     
 var meta = lfs.readMetadata();

--- a/Connectors/Twitter/pull_contacts.js
+++ b/Connectors/Twitter/pull_contacts.js
@@ -20,7 +20,7 @@ var twitterClient = require('twitter-js')(consumerKey, consumerSecret, 'http://1
     app = express.createServer(
     connect.bodyDecoder(),
     connect.cookieDecoder(),
-    connect.session()
+    connect.session({secret : "locker"})
     );
     
 app.get('/',

--- a/Connectors/foursquare/client.js
+++ b/Connectors/foursquare/client.js
@@ -17,7 +17,7 @@ connect = require('connect'),
 app = express.createServer(
 connect.bodyDecoder(),
 connect.cookieDecoder(),
-connect.session()
+connect.session({secret : "locker"})
 );
 
 try { 

--- a/Contexts/facebook.js
+++ b/Contexts/facebook.js
@@ -16,7 +16,7 @@ if (!ctxDir) // Z stat dir
 var fs = require('fs'),http = require('http');
 var express = require('express'),connect = require('connect');
 //facebookClient = require('facebook-js')(appID,appSecret);
-var app = express.createServer(connect.bodyDecoder(), connect.cookieDecoder(), connect.session());
+var app = express.createServer(connect.bodyDecoder(), connect.cookieDecoder(), connect.session({secret : "locker"}));
 
 
 var wwwdude = require('wwwdude'),sys = require('sys');

--- a/Ops/Dashboard/dashboard.js
+++ b/Ops/Dashboard/dashboard.js
@@ -19,7 +19,7 @@ var fs = require('fs'),
 var app = express.createServer(
                 connect.bodyDecoder(),
                 connect.cookieDecoder(),
-                connect.session()
+                connect.session({secret : "locker"})
             );
 
 

--- a/locker.js
+++ b/locker.js
@@ -47,7 +47,7 @@ connect = require('connect');
 locker = express.createServer(
 connect.bodyDecoder(),
 connect.cookieDecoder(),
-connect.session()
+connect.session({secret : "locker"})
 );
 
 // start dashboard


### PR DESCRIPTION
Connect's session middle now requires a session secret for security purposes.  If not provided, an exception is thrown:

Error: session() middleware requires the "secret" option string for security
  at Object.sessionSetup 

This patch resolves this issue by providing a secret.

I experienced this issue using Connect 0.5.7.  A report with further details of the issue can be found here: https://github.com/visionmedia/express/issues/issue/511
