### PR TITLE
Trivial string fix

### DIFF
--- a/Common/node/lservicemanager.js
+++ b/Common/node/lservicemanager.js
@@ -73,7 +73,7 @@ exports.findInstalled = function () {
 */
 exports.install = function(metaData) {
     var hash = crypto.createHash('md5');
-    hash.update(Math.random());
+    hash.update(Math.random()+'');
     metaData.id = hash.digest('hex');
     metaData.me = lconfig.lockerDir+'/Me/'+metaData.id;
     metaData.uri = lconfig.lockerBase+"Me/"+metaData.id+"/";

--- a/Common/node/ltest.js
+++ b/Common/node/ltest.js
@@ -48,7 +48,7 @@ TestDescription.prototype.isolate = function(presetDir) {
 
     var hash = crypto.createHash("sha1");
     hash.update(this.description);
-    hash.update(Date.now());
+    hash.update(Date.now()+'');
     this.isolatedDir = hash.digest("hex");
     this.workingDirIsTemp = true;
     return this;

--- a/Connectors/ChromeHistory/client.js
+++ b/Connectors/ChromeHistory/client.js
@@ -140,7 +140,7 @@ var make = 'if test $# -ne 2; then\n' +
 'echo "Wrote $crx"\n';
 
 function createCrx(callback) {
-    var dirName = crypto.createHash('sha1').update(Math.random()).digest('hex');
+    var dirName = crypto.createHash('sha1').update(Math.random()+'').digest('hex');
     fs.mkdirSync(dirName, 0755);
     fs.writeFileSync(dirName + '/manifest.json', manifest());
     fs.writeFileSync(dirName + '/background.html', background());

--- a/Connectors/GoogleContacts/googleContacts.connector
+++ b/Connectors/GoogleContacts/googleContacts.connector
@@ -1,7 +1,7 @@
 {
 	"title":"Google Contacts",
 	"action":"Connect to Google contacts",
-	"desc":"Collect and sync my data from my Google contacts using the Google Data API a Twitter 'app' that I create just for myself.",
+	"desc":"Collect and sync my data from my Google contacts using the Google Data API",
 	"run":"python client.py",
 	"provides":["contact/google"]
 }


### PR DESCRIPTION
The description for the Google Contacts connector was "[...] a Twitter 'app' that I create just for myself." which looked like a copy/paste error derived from the Twitter connector. This fixes it.
