### PR TITLE
fix foursquare connector

### DIFF
--- a/Connectors/foursquare/client.js
+++ b/Connectors/foursquare/client.js
@@ -204,16 +204,16 @@ function getMe(token, callback) {
     get('api.foursquare.com', '/v2/users/self.json?oauth_token=' + token, callback);
 }
 
-var checkins_limit = 500;
+var checkins_limit = 250;
 function getCheckins(userID, token, offset, callback, checkins) {
     if(!checkins)
         checkins = [];
-    var latest = '';
+    var latest = 1;
     if(me.checkins && me.checkins.latest)
-        latest = '&afterTimestamp=' + me.checkins.latest;
+        latest = me.checkins.latest;
     else if(!me.checkins)
         me.checkins = {};
-    get('api.foursquare.com', '/v2/users/self/checkins.json?limit=' + checkins_limit + '&offset=' + offset + '&oauth_token=' + token + latest,
+    get('api.foursquare.com', '/v2/users/self/checkins.json?limit=' + checkins_limit + '&offset=' + offset + '&oauth_token=' + token + '&afterTimestamp=' + latest,
     function(data) {
         var newCheckins = JSON.parse(data).response.checkins.items;
         checkins.addAll(newCheckins);


### PR DESCRIPTION
Foursquare imposes an api limit of 250 rather than 500, and checkins are reverse chronological order in the absence of an afterTimestamp.  This caused the first import to be in the opposite order of all subsequent imports.  Not sure if it matters or not, but this ensures that the json file is sequential from oldest to most recent.
