### PR TITLE
Unbind click events on app zoom button

### DIFF
--- a/Ops/Dashboard/JavaScripts/Dashboard.js
+++ b/Ops/Dashboard/JavaScripts/Dashboard.js
@@ -132,7 +132,7 @@ function showApp(app, event)
   $("#appTitle").html(app.title);
   // $("#appFrame").attr("src", app.uri || "");
   $("#appFrame")[0].contentWindow.location.replace(app.uri || "");
-  $("#zoomAppButton").click(function() { window.open(app.uri) });
+  $("#zoomAppButton").unbind("click").click(function() { window.open(app.uri) });
 
 }
 


### PR DESCRIPTION
Unbind previously bound click handlers on the zoom button when showing framed apps (closes #68).
