### PR TITLE
Infinite loop in startup caused by mongodb output

### DIFF
--- a/lockerd.js
+++ b/lockerd.js
@@ -67,7 +67,7 @@ path.exists(lconfig.me + '/' + lconfig.mongo.dataDir, function(exists) {
     var mongoOutput = "";
     var callback = function(data) {
         mongoOutput += data;
-        if(mongoOutput.match(/\[initandlisten\] waiting for connections on port/g)) {
+        if(mongoOutput.match(/ waiting for connections on port/g)) {
             mongoProcess.stdout.removeListener('data', callback);
             checkKeys();
         }


### PR DESCRIPTION
On my system `mongoOutput` never matched the regex, even though mongodb had started properly.

I had to change the regex in order for it finish starting.

**System Details**
OS: Ubuntu 10.04
Mongodb: db version v1.2.2, pdfile version 4.5
Debugging Output: https://gist.github.com/996135
