### PR TITLE
Only set browser history state for browsers that support HTML5 pushState

### DIFF
--- a/Ops/Dashboard/JavaScripts/Dashboard.js
+++ b/Ops/Dashboard/JavaScripts/Dashboard.js
@@ -140,6 +140,7 @@ function showApp(app, event)
 
 function setLocation(location)
 {
+  if (!history.pushState) return;
   if (location == getLocation()) return;
   history.pushState({}, "", "#!/" + location);
 }


### PR DESCRIPTION
Don't attempt to set history state unless the browser actually supports it, for now.

The real fix, coming later, will be to fallback to setting the location hash for older browsers.

This closes issue #76.
