### PR TITLE
Use express' built-in static file server.

### DIFF
--- a/Ops/Dashboard/dashboard-client.js
+++ b/Ops/Dashboard/dashboard-client.js
@@ -88,32 +88,6 @@ app.get('/post2install', function(req, res){
 });
 
 
-app.get('/*', function (req, res) {
-    var uri = url.parse(req.url).pathname;
-    var filename = path.join(process.cwd(), uri);  
-    path.exists(filename, function(exists) { 
-        if(!exists) {  
-            res.writeHead(404, {"Content-Type": "text/plain"});  
-            res.write("404 Not Found\n");  
-            res.end();  
-            return;  
-        }  
-
-        fs.readFile(filename, "binary", function(err, file) {
-            if(err) {
-                res.writeHead(500, {"Content-Type": "text/plain"}); 
-                res.write(err + "\n");
-                res.end();
-                return;
-            }  
-
-            var fileExtension = filename.substring(filename.lastIndexOf(".") + 1);
-            var contentType, contentLength;
-            res.writeHead(200);
-            res.write(file, "binary");
-            res.end();
-        });
-    });
-});
+app.use(express.static(__dirname));
 
 app.listen(rootPort);


### PR DESCRIPTION
Use express' built-in static file server instead of a homebrewed one, a bit DRY-er.

Re-submitted by request from https://github.com/LockerProject/Locker/pull/22
