### PR TITLE
Keep stale provider data from persisting when switching to a service with

### DIFF
--- a/Ops/Dashboard/dashboard-static/js/dashboard.js
+++ b/Ops/Dashboard/dashboard-static/js/dashboard.js
@@ -89,7 +89,7 @@ function selectService(index) {
     $("#serviceInfo p").html(item["desc"]);
     $("#availType").html(item["is"]);
     $("#availSrcDir").html(item["srcdir"]);
-    if (item["provides"]) $("#availProvides").html(item["provides"].join(", "));
+    $("#availProvides").html(item["provides"] ? item["provides"].join(", ") : '');
     $("#connectorInstancesList").children().remove();
     $("#installButton a").attr("href", "javascript:installService(" + index + ");");
     $("#installButton").show();


### PR DESCRIPTION
Ex: toggling from Twitter to Developer Documentation in the Services panel won't erroneously tell you the dev docs provide "contact/twitter, status/twitter, link/twitter" now.
