### PR TITLE
fix 3 failing twitter connector tests

### DIFF
--- a/tests/connector-local-twitter-test.js
+++ b/tests/connector-local-twitter-test.js
@@ -214,7 +214,7 @@ suite.next().suite.addBatch({
                 "successfully": function(err, response) {
                     assert.isNull(err);
                     assert.equal(response.length, 1);
-                    assert.equal(response[0].id.toNumber(), 71348168469643260);
+                    assert.equal(response[0].id, '71348168469643260');
                 }
             },
             "user_timeline returns" : {
@@ -223,7 +223,7 @@ suite.next().suite.addBatch({
                 "successfully": function(err, response) {
                     assert.isNull(err);
                     assert.equal(response.length, 1);
-                    assert.equal(response[0].id.toNumber(), 73036575310757890);
+                    assert.equal(response[0].id, '73036575310757890');
                 }
             },
             "mentions returns" : {
@@ -232,7 +232,7 @@ suite.next().suite.addBatch({
                 "successfully": function(err, response) {
                     assert.isNull(err);
                     assert.equal(response.length, 1);
-                    assert.equal(response[0].id.toNumber(), 73034804081344510);
+                    assert.equal(response[0].id, '73034804081344510');
                 }
             }
         }


### PR DESCRIPTION
convert .toNumber calls in twitter tests to string compares since method not present

  Datastore function getStatusesCurrent from home_timeline returns
    ‚úó successfully
    TypeError: Object 71348168469643260 has no method 'toNumber'
    at Object.<anonymous> (/workspace/Locker/tests/connector-local-twitter-test.js:217:49)
    at runTest (/workspace/Locker/node_modules/vows/lib/vows.js:95:26)
    at EventEmitter.<anonymous> (/workspace/Locker/node_modules/vows/lib/vows.js:73:9)
    at EventEmitter.emit (events.js:81:20)
    at /workspace/Locker/node_modules/vows/lib/vows/context.js:32:52
    at /workspace/Locker/node_modules/vows/lib/vows/context.js:46:29
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:130:9
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:176:11
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:489:35
    at Array.0 (/workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:661:7)
  Datastore function getStatusesCurrent from user_timeline returns
    ‚úó successfully
    TypeError: Object 73036575310757890 has no method 'toNumber'
    at Object.<anonymous> (/workspace/Locker/tests/connector-local-twitter-test.js:226:49)
    at runTest (/workspace/Locker/node_modules/vows/lib/vows.js:95:26)
    at EventEmitter.<anonymous> (/workspace/Locker/node_modules/vows/lib/vows.js:73:9)
    at EventEmitter.emit (events.js:81:20)
    at /workspace/Locker/node_modules/vows/lib/vows/context.js:32:52
    at /workspace/Locker/node_modules/vows/lib/vows/context.js:46:29
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:130:9
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:176:11
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:489:35
    at Array.1 (/workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:661:7)
  Datastore function getStatusesCurrent from mentions returns
    ‚úó successfully
    TypeError: Object 73034804081344510 has no method 'toNumber'
    at Object.<anonymous> (/workspace/Locker/tests/connector-local-twitter-test.js:235:49)
    at runTest (/workspace/Locker/node_modules/vows/lib/vows.js:95:26)
    at EventEmitter.<anonymous> (/workspace/Locker/node_modules/vows/lib/vows.js:73:9)
    at EventEmitter.emit (events.js:81:20)
    at /workspace/Locker/node_modules/vows/lib/vows/context.js:32:52
    at /workspace/Locker/node_modules/vows/lib/vows/context.js:46:29
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:130:9
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:176:11
    at /workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:489:35
    at Array.2 (/workspace/Locker/node_modules/mongodb/lib/mongodb/cursor.js:661:7)
