### PR TITLE
Fixed misspelling of the word Foursquare.

### DIFF
--- a/Apps/FoursquareMayors/foursquaremayors.app
+++ b/Apps/FoursquareMayors/foursquaremayors.app
@@ -1,7 +1,7 @@
 {
 	"title":"Foursquare Mayors",
     "action":"View Foursquare Mayors",
-	"desc":"Map your friend's mayorships from Foursqaure",
+	"desc":"Map your friend's mayorships from Foursquare",
 	"status":"stable",
 	"run":"node foursquaremayors-server.js",
 	"handle":"foursquaremayors"


### PR DESCRIPTION
Fixes silly typo in the spelling of Foursquare
