### PR TITLE
Fix for dep version check only doing greater than comparison

### DIFF
--- a/checkEnv.sh
+++ b/checkEnv.sh
@@ -16,7 +16,7 @@ check_for() {
         fi
     fi
     if [ -n "$4" ]; then
-        result=`python -c 'print tuple("$version".split(".")) > tuple("$4".split("."))'`
+        result=`python -c 'print tuple("$version".split(".")) >= tuple("$4".split("."))'`
         if [ "$result" = "False" ]; then
             echo "${txtred}$1 version $4 or greater required!${txtrst}" >&2
         fi


### PR DESCRIPTION
Shell out to python currently only does a ">" rather than ">=" so if Python 2.6 is required and 2.6 (but not 2.6.1) is installed, it will erroneously fail.
