### PR TITLE
fix venueless checkins and not bail on one bad item

### DIFF
--- a/Collections/Places/migrations/1370000000000.js
+++ b/Collections/Places/migrations/1370000000000.js
@@ -1,0 +1,3 @@
+module.exports = function(dir) {
+    return "update";
+};


### PR DESCRIPTION
Some checkins don't have a venue, only a location, and when they were encountered during an update they would bail everything in the queue.  This has a migration to re-update and get any missed too.
