### PR TITLE
Fixes for #435

### DIFF
--- a/Collections/Links/links.js
+++ b/Collections/Links/links.js
@@ -151,6 +151,7 @@ function genericApi(name,f)
 
 // expose way to get raw links and encounters
 app.get('/', function(req, res) {
+    var full = (req.query.full === true || req.query.full === "true" || req.query.full == 1);
     var fullResults = [];
     var results = [];
     var options = {sort:{"at":-1}};
@@ -161,22 +162,47 @@ app.get('/', function(req, res) {
     if (req.query.offset) {
         options.offset = parseInt(req.query.offset);
     }
+    var deleteLink = false;
     if (req.query.fields) {
         try {
             options.fields = JSON.parse(req.query.fields);
+            // we need the link field for merging encounters and links objects
+            // so get it, but flag it for deletion if not requested
+            if(!options.fields.hasOwnProperty('link') || options.fields.link == 0) {
+                options.fields.link = 1;
+                deleteLink = true;
+            }
         } catch(E) {}
     }
     var ndx = {};
     dataStore.getLinks(options, function(item) {
-        item.encounters = [];
+        if(full)
+            item.encounters = [];
         ndx[item.link] = item;
+        if(deleteLink) // delete the link field if it wasn't requested
+            delete item.link;
         results.push(item);
     }, function(err) {
-        if(req.query.full === true || req.query.full === "true" || req.query.full == 1) {
+        if(full) {
             var arg = {"link":{$in: Object.keys(ndx)}};
-            if(options.fields) arg.fields = options.fields;
+            if(options.fields) {
+                arg.fields = {};
+                // extract only encounter.* fields
+                for(var i in options.fields) {
+                    if(i.length > 11 && i.substring(0,11) === 'encounters.')
+                        arg.fields[i.substring(11)] = options.fields[i];
+                }
+                // we need the link field for merging encounters and links objects
+                // so get it, but flag it for deletion if not requested
+                if(!arg.fields.hasOwnProperty('link') || arg.fields.link == 0) {
+                    arg.fields.link = 1;
+                    deleteLink = true;
+                }
+            }
             dataStore.getEncounters(arg, function(encounter) {
                 ndx[encounter.link].encounters.push(encounter);
+                if(deleteLink) // delete the link field if it wasn't requested
+                    delete encounter.link;
             }, function() {
                 res.send(results);
             });


### PR DESCRIPTION
Added to logic to properly retrieve fields from the "encounters" mongo collection as specified by {"encounters.*":1/0} in the fields param. Also, always pull link field out of the DB as it is used for deduping and delete it from the object before returning if it wasn't requested.

As this alters an API, it felt better to do a pull req instead of just pushing right into master. Could I ask a 2 people to check it out, look at the code, and make sure it works in the way they would expect? There is stilla bit of strange thing in that you can set full=true and fields={"encounters":0} and you will get the encounters back - it would be an easy fix, but that would be a not-necessarily expected change, so I left it out for now.
