### PR TITLE
Date.now() instead of new Date().getTime()

### DIFF
--- a/Collections/Contacts/contacts.js
+++ b/Collections/Contacts/contacts.js
@@ -35,7 +35,7 @@ app.get('/state', function(req, res) {
             if(err) return res.send(err, 500);
             var objId = "000000000000000000000000";
             if (lastObject) objId = lastObject._id.toHexString();
-            var updated = new Date().getTime();
+            var updated = Date.now();
             try {
                 var js = JSON.parse(fs.readFileSync('state.json'));
                 if(js && js.updated) updated = js.updated;

--- a/Collections/Contacts/dataStore.js
+++ b/Collections/Contacts/dataStore.js
@@ -53,7 +53,7 @@ function updateState()
     }
     writeTimer = setTimeout(function() {
         try {
-            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:new Date().getTime()}));
+            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:Date.now()}));
         } catch (E) {}
     }, 5000);
 }
@@ -91,7 +91,7 @@ exports.addTwitterData = function(data, callback) {
     var cleanedName = cleanName(data.name);
     var query = {'accounts.twitter.data.id':twID};
     var set = {};
-    var baseObj = {data:data, lastUpdated:new Date().getTime()};
+    var baseObj = {data:data, lastUpdated:Date.now()};
     set['accounts.twitter.$'] = baseObj;
     //name
     setName(set, data.name);
@@ -128,7 +128,7 @@ exports.addGithubData = function(data, callback) {
     var cleanedName = cleanName(data.name);
     var query = {'accounts.github.data.id':data.id};
     var set = {};
-    var baseObj = {data:data, lastUpdated:new Date().getTime()};
+    var baseObj = {data:data, lastUpdated:Date.now()};
     set['accounts.github.$'] = baseObj;
     //name
     setName(set, data.name);
@@ -177,7 +177,7 @@ exports.addFoursquareData = function(data, callback) {
     var cleanedName = cleanName(name);
     var query = {'accounts.foursquare.data.id':foursquareID};
     var set = {};
-    var baseObj = {data:data, lastUpdated:new Date().getTime()};
+    var baseObj = {data:data, lastUpdated:Date.now()};
     set['accounts.foursquare.$'] = baseObj;
     //name
     setName(set, name);
@@ -236,7 +236,7 @@ exports.addFacebookData = function(data, callback) {
     var cleanedName = cleanName(data.name);
     var query = {'accounts.facebook.data.id':fbID};
     var set = {};
-    var baseObj = {data:data, lastUpdated:new Date().getTime()};
+    var baseObj = {data:data, lastUpdated:Date.now()};
     set['accounts.facebook.$'] = baseObj;
     //name
     setName(set, data.name);
@@ -272,7 +272,7 @@ exports.addGoogleContactsData = function(data, callback) {
     var cleanedName = cleanName(data.name);
     var query = {'accounts.googleContacts.data.id':gcID};
     var set = {};
-    var baseObj = {data:data, lastUpdated:new Date().getTime()};
+    var baseObj = {data:data, lastUpdated:Date.now()};
     set['accounts.googleContacts.$'] = baseObj;
     setName(set, data.name);
 

--- a/Collections/Links/dataStore.js
+++ b/Collections/Links/dataStore.js
@@ -125,7 +125,7 @@ function updateState()
     }
     writeTimer = setTimeout(function() {
         try {
-            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:new Date().getTime()}));
+            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:Date.now()}));
         } catch (E) {}
     }, 5000);
 }

--- a/Collections/Links/links.js
+++ b/Collections/Links/links.js
@@ -37,7 +37,7 @@ app.get('/state', function(req, res) {
             if(err) return res.send(err, 500);
             var objId = "000000000000000000000000";
             if (lastObject) objId = lastObject._id.toHexString();
-            var updated = new Date().getTime();
+            var updated = Date.now();
             try {
                 var js = JSON.parse(fs.readFileSync('state.json'));
                 if(js && js.updated) updated = js.updated;

--- a/Collections/Photos/dataStore.js
+++ b/Collections/Photos/dataStore.js
@@ -198,7 +198,7 @@ function updateState()
     }
     writeTimer = setTimeout(function() {
         try {
-            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:new Date().getTime()}));
+            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:Date.now()}));
         } catch (E) {}
     }, 5000);
 }

--- a/Collections/Photos/photos.js
+++ b/Collections/Photos/photos.js
@@ -29,7 +29,7 @@ app.get('/state', function(req, res) {
             if(err) return res.send(err, 500);
             var objId = "000000000000000000000000";
             if (lastObject) objId = lastObject._id.toHexString();
-            var updated = new Date().getTime();
+            var updated = Date.now();
             try {
                 var js = JSON.parse(fs.readFileSync('state.json'));
                 if(js && js.updated) updated = js.updated;

--- a/Collections/Places/dataStore.js
+++ b/Collections/Places/dataStore.js
@@ -139,7 +139,7 @@ function updateState() {
     }
     writeTimer = setTimeout(function() {
         try {
-            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:new Date().getTime()}));
+            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:Date.now()}));
         } catch (E) {}
     }, 5000);
 }

--- a/Collections/Places/places.js
+++ b/Collections/Places/places.js
@@ -29,7 +29,7 @@ app.get('/state', function(req, res) {
             if(err) return res.send(err, 500);
             var objId = "000000000000000000000000";
             if (lastObject) objId = lastObject._id.toHexString();
-            var updated = new Date().getTime();
+            var updated = Date.now();
             try {
                 var js = JSON.parse(fs.readFileSync('state.json'));
                 if(js && js.updated) updated = js.updated;

--- a/Collections/Search/search.js
+++ b/Collections/Search/search.js
@@ -376,7 +376,7 @@ function makeEnrichedRequest(url, item, callback) {
         item.fullobject = body;
 
         if (item.fullobject.hasOwnProperty('created_at')) {
-            var dateDiff = new Date(new Date().getTime() - new Date(item.fullobject.created_at).getTime());
+            var dateDiff = new Date(Date.now() - new Date(item.fullobject.created_at).getTime());
             if (dateDiff.getUTCDate() > 2) {
                 item.fullobject.created_at_since = (dateDiff.getUTCDate() - 2) + ' day';
                 if (dateDiff.getUTCDate() > 3) item.fullobject.created_at_since += 's';

--- a/Common/node/connector/dataStore.js
+++ b/Common/node/connector/dataStore.js
@@ -31,7 +31,7 @@ exports.addCollection = function(name) {
 }
 
 function now() {
-    return new Date().getTime();
+    return Date.now();
 }
 
 // arguments: type should match up to one of the mongo collection fields

--- a/Common/node/ldatastore.js
+++ b/Common/node/ldatastore.js
@@ -165,6 +165,6 @@ function getMongo(owner, type, callback) {
 }
 
 function now() {
-    return new Date().getTime();
+    return Date.now();
 }
 

--- a/Common/node/locker.js
+++ b/Common/node/locker.js
@@ -36,11 +36,11 @@ exports.initClient = function(instanceInfo) {
 };
 
 exports.at = function(uri, delayInSec, stateField) {
-    if(stateField) lstate.next(stateField,(new Date().getTime() + (delayInSec * 1000)));
+    if(stateField) lstate.next(stateField,(Date.now() + (delayInSec * 1000)));
     request.get({
         url:baseServiceUrl + '/at?' + querystring.stringify({
             cb:uri,
-            at:((new Date().getTime() + (delayInSec * 1000))/1000)
+            at:((Date.now() + (delayInSec * 1000))/1000)
             })
     });
 };

--- a/Common/node/lstate.js
+++ b/Common/node/lstate.js
@@ -33,7 +33,7 @@ exports.set = function(field,val){
 
 exports.next = function(field, at){
     stateIt[field+'Next'] = at;
-    stateUpdated = new Date().getTime();
+    stateUpdated = Date.now();
 }
 
 exports.state = function()
@@ -48,13 +48,13 @@ exports.init = function()
     } catch(e){
         stateIt = {};
     }
-    stateUpdated = stateSynced = new Date().getTime();
+    stateUpdated = stateSynced = Date.now();
     stateSync();
 }
 
 function stateChange(field)
 {
-    stateIt[field+"Last"] = stateIt["updated"] = stateUpdated = new Date().getTime();    
+    stateIt[field+"Last"] = stateIt["updated"] = stateUpdated = Date.now();    
 }
 
 function stateSync()

--- a/Common/node/ltest.js
+++ b/Common/node/ltest.js
@@ -121,7 +121,7 @@ exports.testSuite = {
         }
         // Cleanup and output
         if (self.testPosition >= self.tests.length) {
-            var runTime = (new Date().getTime() - self.startTime.getTime()) / 1000;
+            var runTime = (Date.now() - self.startTime.getTime()) / 1000;
             process.stdout.write("\nRan " + self.tests.length + " tests in " + 
                 runTime + " seconds " + self.successes + " successes " + self.failures + " failures.\n");
             return;

--- a/Connectors/Flickr/client.js
+++ b/Connectors/Flickr/client.js
@@ -203,7 +203,7 @@ function getPhotos(auth_token, username, user_id, page, oldest, newest) {
     if(!oldest)
         oldest = 0;
     if(!newest)
-        newest = new Date().getTime()/1000;
+        newest = Date.new()/1000;
     var url = getSignedMethodURL('flickr.people.getPhotos',
                                 ['auth_token=' + auth_token, 'user_id=' + user_id,
                                  'min_upload_date=' + oldest, 'max_upload_date=' + newest,
@@ -260,7 +260,7 @@ function(req, res) {
     res.writeHead(200, {
         'Content-Type': 'text/html'
     });
-    var now = new Date().getTime()/1000;
+    var now = Date.new()/1000;
     getPhotos(auth.token._content, userInfo.username, 'me', 1, state.newest, now);
     state.newest = now;
     lfs.writeObjectToFile('state.json', state);

--- a/Connectors/GoogleContacts/sync.js
+++ b/Connectors/GoogleContacts/sync.js
@@ -53,7 +53,7 @@ exports.syncContacts = function(callback) {
                   'orderby':'lastmodified',
                   'max-results':3000
                  };
-    var now = new Date().getTime();
+    var now = Date.new();
     getClient().getFeed('https://www.google.com/m8/feeds/contacts/default/full', params,
         function(err, result) {
             if(result && !(err && result.error)) {
@@ -81,7 +81,7 @@ exports.syncGroups = function(callback) {
                   'orderby':'lastmodified',
                   'max-results':3000
                  };
-    var now = new Date().getTime();
+    var now = Date.new();
     getClient().getFeed('https://www.google.com/m8/feeds/groups/default/full', params,
         function(err, result) {
             if(result && !(err && result.error)) {

--- a/Connectors/LastFM/last.fm.js
+++ b/Connectors/LastFM/last.fm.js
@@ -84,7 +84,7 @@ function nowSec() {
     return now() / 1000;
 }
 function now() {
-    return new Date().getTime();
+    return Date.new();
 }
 
 function readMeta(user) {

--- a/Connectors/Twitter/sync.js
+++ b/Connectors/Twitter/sync.js
@@ -378,7 +378,7 @@ function getTwitterClient() {
 exports.getRateLimitStatus = function(callback) {
     request.get({uri:'http://api.twitter.com/1/account/rate_limit_status.json'}, function(err, resp, body) {
         var limits = JSON.parse(body);
-        var remainingTime = limits.reset_time_in_seconds - (new Date().getTime() / 1000);
+        var remainingTime = limits.reset_time_in_seconds - (Date.now() / 1000);
         if(limits.remaining_hits)
             limits.sec_between_calls = remainingTime / limits.remaining_hits;
         else

--- a/Ops/TeleHash/telehash.js
+++ b/Ops/TeleHash/telehash.js
@@ -32,7 +32,7 @@ exports.keys = keys;
  * See time(2).
  */
 function time() {
-    return new Date().getTime() / 1000;
+    return Date.now() / 1000;
 }
 
 /**


### PR DESCRIPTION
the calls are 25% faster - seems to be the better way. Really no big deal since we don't call it _that_ often, but in aggregate worth getting right.

A reference benchmark, for which I got the same results in node (makes sense because of V8): http://jsperf.com/new-date-value/3
