### PR TITLE
Proposal: Strip out status object from twitter friends

### DIFF
--- a/Common/node/ldatastore.js
+++ b/Common/node/ldatastore.js
@@ -51,7 +51,8 @@ exports.addObject = function(owner, type, object, options, callback) {
     if (arguments.length == 3) callback = options;
     if (typeof options == 'object') {
         for (var i in options['strip']) {
-            object[options['strip'][i]].delete
+            var key = options['strip'][i];
+            delete object[key];
         }
         if (options['timeStamp']) {
             timeStamp = options['timeStamp'];

--- a/Common/node/lsyncmanager.js
+++ b/Common/node/lsyncmanager.js
@@ -431,7 +431,10 @@ function addData (collection, mongoId, data, info, idr, callback) {
                 levents.fireEvent(url.format(r), 'delete');
                 datastore.removeObject(collection, object.obj[mongoId], {timeStamp: object.timestamp}, cb);
             } else {
-                datastore.addObject(collection, object.obj, {timeStamp: object.timestamp}, function(err, type, doc) {
+                var source = r.pathname.substring(1);
+                var options = {timeStamp: object.timestamp};
+                if(info.strip && info.strip[source]) options.strip = info.strip[source];
+                datastore.addObject(collection, object.obj, options, function(err, type, doc) {
                     if (type === 'same') return cb();
                     levents.fireEvent(url.format(r), type, doc);
                     return cb();

--- a/Connectors/Twitter/twitter.synclet
+++ b/Connectors/Twitter/twitter.synclet
@@ -13,6 +13,9 @@
         "tweets":"tweet",
         "mentions":"tweet"
     },
+    "strip" : {
+        "contact":["status"]
+    },
     "synclets":[{"name": "related", "frequency": 3600},
                 {"name": "friends", "frequency": 3600},
                 {"name": "timeline", "frequency": 120},


### PR DESCRIPTION
Per #244. I'd like to hear what people think about this. It's a complete duplication of info, but this would be a modification of the original data from Twitter, so our data/API wouldn't as closely replicate Twitter's. 

I lean in favor of stripping it out - the combination of those two data types feels more appropriate as a join than an embed.
