### PR TITLE
Pull to use lockerHost in config.json

### DIFF
--- a/Common/node/lconfig.js
+++ b/Common/node/lconfig.js
@@ -21,6 +21,7 @@ exports.load = function(filepath) {
     }
     exports.lockerHost = config.lockerHost || 'localhost';
     exports.externalHost = config.externalHost || 'localhost';
+    exports.lockerListenIP = config.lockerListenIP || '0.0.0.0';
     exports.lockerPort = config.lockerPort || 8042;
     if(config.externalPort)
         exports.externalPort = config.externalPort;

--- a/Config/config.json.example
+++ b/Config/config.json.example
@@ -1,5 +1,6 @@
 {
     "lockerHost" : "localhost",
+    "lockerListenIP" : "0.0.0.0",
     "lockerPort" : 8042,
     "me" : "Me",
     "scannedDirs" : [

--- a/Ops/webservice.js
+++ b/Ops/webservice.js
@@ -488,8 +488,8 @@ function proxied(method, svc, ppath, req, res, buffer) {
     });
 }
 
-exports.startService = function(port, cb) {
-    locker.listen(port, function(){
+exports.startService = function(port, ip, cb) {
+    locker.listen(port, ip, function(){
         cb(locker);
     });
 }

--- a/_lockerd.js
+++ b/_lockerd.js
@@ -141,7 +141,7 @@ function finishStartup() {
     pushManager.init();
     var webservice = require(__dirname + "/Ops/webservice.js");
     // start web server (so we can all start talking)
-    webservice.startService(lconfig.lockerPort, function(locker){
+    webservice.startService(lconfig.lockerPort, lconfig.lockerHost, function(locker){
         // ordering sensitive, as synclet manager is inert during init, servicemanager's init will call into syncletmanager
         syncManager.init(serviceManager, function(){
             registry.init(serviceManager, syncManager, lconfig, lcrypto, function(){

--- a/_lockerd.js
+++ b/_lockerd.js
@@ -141,7 +141,7 @@ function finishStartup() {
     pushManager.init();
     var webservice = require(__dirname + "/Ops/webservice.js");
     // start web server (so we can all start talking)
-    webservice.startService(lconfig.lockerPort, lconfig.lockerHost, function(locker){
+    webservice.startService(lconfig.lockerPort, lconfig.lockerListenIP, function(locker){
         // ordering sensitive, as synclet manager is inert during init, servicemanager's init will call into syncletmanager
         syncManager.init(serviceManager, function(){
             registry.init(serviceManager, syncManager, lconfig, lcrypto, function(){


### PR DESCRIPTION
Code to use lockerHost in config.json to allow custom host locker server listens to.
