### PR TITLE
Sync user events from GitHub

### DIFF
--- a/Connectors/GitHub/synclets.json
+++ b/Connectors/GitHub/synclets.json
@@ -14,6 +14,10 @@
         },
         {
             "frequency": 3600,
+            "name": "userEvents"
+        },
+        {
+            "frequency": 3600,
             "name": "events"
         }
     ],
@@ -21,6 +25,7 @@
         "contact/github",
         "repo/github",
         "event/github",
+        "userEvent/github",
         "view/github"
     ]
 }

--- a/Connectors/GitHub/userEvents.js
+++ b/Connectors/GitHub/userEvents.js
@@ -1,0 +1,38 @@
+var request = require("request");
+
+exports.sync = function(processInfo, cb) {
+   var arg = processInfo.auth;
+
+   arg.userEvents = [];
+
+   page(arg, function(err) {
+      cb(err, {data: {userEvent: arg.userEvents}});
+   });
+};
+
+function page(arg, callback)
+{
+   if (!arg.url) {
+      arg.url = "https://api.github.com/users/" + arg.profile.login + "/events?per_page=100&access_token=" + arg.accessToken;
+   }
+
+   var api = arg.url;
+
+   if (arg.page) {
+      api += "&page=" + arg.page;
+   }
+
+   request.get({uri: api, json: true}, function(err, resp, body) {
+      if (err || !body || !Array.isArray(body) || body.length === 0) {
+         return callback(err);
+      }
+
+      body.forEach(function(e) {
+         arg.userEvents.push(e);
+      });
+
+      arg.page = (arg.page) ? arg.page + 1 : 2;
+
+      page(arg, callback);
+   });
+}


### PR DESCRIPTION
The GitHub connector currently syncs events from repos and users that the Locker owner is watching. This patch implements the ability to sync the Locker owner's own events (pushes, commits, comments, etc.).

Tested successfully on my machine.

It might also be useful to rename the current 'event' collection to something like 'watchEvent' to differentiate it...
