### PR TITLE
Fix for issue #733 successful startup logging at error level

### DIFF
--- a/_lockerd.js
+++ b/_lockerd.js
@@ -203,7 +203,7 @@ function runMigrations(phase, migrationCB) {
 // scheduling and misc things
 function postStartup() {
     lscheduler.masterScheduler.loadAndStart();
-    logger.info('locker is up and running at ' + lconfig.lockerBase);
+    logger.error('locker is up and running at ' + lconfig.lockerBase);
     exports.alive = true;
     runMigrations("postStartup", function() {});
 }


### PR DESCRIPTION
Not sure if this is just a personal itch - but I find myself wanting to know when locker is up and running, without the info logging level (#733)
