### PR TITLE
Update to the Develop-BuildAnApp page

### DIFF
--- a/Apps/dashboardv3/views/iframe/develop-buildapp.ejs
+++ b/Apps/dashboardv3/views/iframe/develop-buildapp.ejs
@@ -125,7 +125,7 @@
             <p>Take a screenshot and put it in the root directory of your app as screenshot.png</p>
           </li>
           <li><h3>Push to GitHub:</h3>
-            <p>Commit your changes and push to GitHub. Be sure to add js/config.js to the .gitignore:</p>
+            <p>Commit your changes and push to GitHub.</p>
             <pre class="prettyprint">git add  .<br>git commit -m 'ready to go'<br>git push origin master</pre>
             <p>Your app will be synced to your Singly account automatically.</p>
           </li>


### PR DESCRIPTION
I was working through the steps for publishing an app and noticed that there was some old documentation in there.
Removed the offending line.
SessionStorage api key hack is a slick way to get rid of the config files.
