### PR TITLE
Collection data access APIs --> core

### DIFF
--- a/Collections/Contacts/api.js
+++ b/Collections/Contacts/api.js
@@ -1,0 +1,74 @@
+var fs = require('fs');
+var path = require('path');
+var locker = require('locker');
+var logger = require('logger');
+var request = require('request');
+var url = require('url');
+
+module.exports = function(app, lockerInfo) {
+
+  var dataStore = require(path.join(lockerInfo.sourceDirectory, 'dataStore.js'));
+  locker.initClient(lockerInfo);
+
+  locker.connectToMongo(function(mongo) {
+    // initialize all our libs
+    dataStore.init(mongo, locker, lockerInfo);
+    // TODO: this is a race condition. The routes will be added before the dataStore is initialized
+    // callback();
+  });
+
+
+  app.get('/state', function(req, res) {
+    dataStore.state(function(err, state) {
+      if(err) return res.send(err, 500)
+      res.send(state);
+    });
+  });
+
+
+  app.get('', function(req, res) {
+    var fields = {};
+    if (req.query.fields) {
+      try {
+        fields = JSON.parse(req.query.fields);
+      } catch(E) {}
+    }
+    dataStore.getAll(fields, function(err, cursor) {
+      if(!req.query.all) cursor.limit(20); // default 20 unless all is set
+      if(req.query.limit) cursor.limit(parseInt(req.query.limit));
+      if(req.query.offset) cursor.skip(parseInt(req.query.offset));
+      if(req.query.stream == 'true') {
+        res.writeHead(200, {'content-type' : 'application/jsonstream'});
+        cursor.each(function(err, object){
+          if (err) logger.error(err); // only useful here for logging really
+          if (!object) return res.end();
+          res.write(JSON.stringify(object)+'\n');
+        });
+      } else {
+        cursor.toArray(function(err, items) {
+          res.send(items);
+        });
+      }
+    });
+  });
+
+  app.get('/since', function(req, res) {
+    if (!req.query.id) return res.send([]);
+
+    var results = [];
+    dataStore.getSince(req.query.id, function(item) {
+      results.push(item);
+    }, function() {
+      res.send(results);
+    });
+  });
+
+  app.get('/id/:id', function(req, res, next) {
+    if (req.param('id').length != 24) return next(req, res, next);
+    dataStore.get(req.param('id'), function(err, doc) {
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify(doc));
+    });
+  });
+
+}

--- a/Collections/Contacts/contacts.js
+++ b/Collections/Contacts/contacts.js
@@ -9,65 +9,14 @@
 
 // merge contacts from connectors
 
-var fs = require('fs')
-  , locker = require('locker.js')
-  , express = require('express')
-  , connect = require('connect')
-  , lutil = require('lutil')
-  , url = require('url')
-  , sync = require('./sync')
-  , dataStore = require('./dataStore')
-  , logger
-  , lockerInfo
-  ;
+var locker = require('locker.js');
+var express = require('express');
+var connect = require('connect');
+var url = require('url');
+var sync = require('./sync');
+var dataStore = require('./dataStore');
 
 var app = express.createServer(connect.bodyParser());
-
-app.set('views', __dirname);
-
-app.get('/state', function(req, res) {
-    dataStore.getTotalCount(function(err, countInfo) {
-        if(err) return res.send(err, 500);
-        dataStore.getLastObjectID(function(err, lastObject) {
-            if(err) return res.send(err, 500);
-            var objId = '000000000000000000000000';
-            if (lastObject) objId = lastObject._id.toHexString();
-            var updated = Date.now();
-            try {
-                var js = JSON.parse(fs.readFileSync('state.json'));
-                if(js && js.updated) updated = js.updated;
-            } catch(E) {}
-            res.send({ready:1, count:countInfo, updated:updated, lastId:objId});
-        });
-    });
-});
-
-
-app.get('/', function(req, res) {
-    var fields = {};
-    if (req.query.fields) {
-        try {
-            fields = JSON.parse(req.query.fields);
-        } catch(E) {}
-    }
-    dataStore.getAll(fields, function(err, cursor) {
-        if(!req.query.all) cursor.limit(20); // default 20 unless all is set
-        if(req.query.limit) cursor.limit(parseInt(req.query.limit));
-        if(req.query.offset) cursor.skip(parseInt(req.query.offset));
-        if(req.query.stream == 'true') {
-            res.writeHead(200, {'content-type' : 'application/jsonstream'});
-            cursor.each(function(err, object){
-                if (err) logger.error(err); // only useful here for logging really
-                if (!object) return res.end();
-                res.write(JSON.stringify(object)+'\n');
-            });
-        } else {
-            cursor.toArray(function(err, items) {
-                res.send(items);
-            });
-        }
-    });
-});
 
 var updating = false;
 app.get('/update', function(req, res) {
@@ -80,11 +29,7 @@ app.get('/update', function(req, res) {
 });
 
 app.post('/events', function(req, res) {
-    if (!req.body.idr || !req.body.data) {
-        logger.error('5 HUNDO');
-        res.send('bad data', 500);
-        return;
-    }
+    if (!req.body.idr || !req.body.data) return res.send('bad data', 500);
     // we don't support these yet
     if(req.body.action == 'delete') return res.send('skipping');
     var idr = url.parse(req.body.idr);
@@ -94,29 +39,10 @@ app.post('/events', function(req, res) {
     });
 });
 
-app.get('/since', function(req, res) {
-    if (!req.query.id) return res.send([]);
-
-    var results = [];
-    dataStore.getSince(req.query.id, function(item) {
-        results.push(item);
-    }, function() {
-        res.send(results);
-   });
-});
-
-app.get('/id/:id', function(req, res, next) {
-    if (req.param('id').length != 24) return next(req, res, next);
-    dataStore.get(req.param('id'), function(err, doc) {
-        res.writeHead(200, {'Content-Type': 'application/json'});
-        res.end(JSON.stringify(doc));
-    })
-});
-
 // Process the startup JSON object
 process.stdin.resume();
 process.stdin.on('data', function(data) {
-    lockerInfo = JSON.parse(data);
+    var lockerInfo = JSON.parse(data);
     locker.initClient(lockerInfo);
     if (!lockerInfo || !lockerInfo.workingDirectory) {
         process.stderr.write('Was not passed valid startup information.'+data+'\n');
@@ -126,9 +52,8 @@ process.stdin.on('data', function(data) {
 
     var lconfig = require('lconfig');
     lconfig.load('../../Config/config.json');
-    logger = require('logger.js');
     locker.connectToMongo(function(mongo) {
-        sync.init(lockerInfo.lockerUrl, mongo.collections.contact, mongo, lconfig);
+        sync.init(lockerInfo.lockerUrl, mongo, locker, lconfig);
         app.listen(0, function() {
             var returnedInfo = {port: app.address().port};
             process.stdout.write(JSON.stringify(returnedInfo));

--- a/Collections/Contacts/dataStore.js
+++ b/Collections/Contacts/dataStore.js
@@ -39,6 +39,7 @@ exports.addData = function(type, data, cb) {
   // shim to send events, post-add stuff
   if(typeof inserters[type] !== 'function') return cb(new Error('unhandled data type,' + type));
   inserters[type](data, type, function(err, doc) {
+    if(err) return cb(err);
     if(doc && doc._id) {
       var idr = lutil.idrNew('contact', 'contacts', doc._id);
       locker.ievent(idr, doc);

--- a/Collections/Contacts/sync.js
+++ b/Collections/Contacts/sync.js
@@ -8,17 +8,18 @@
 */
 
 var request = require('request');
-var locker = require('locker.js');
+var locker;
 var lconfig;
 var dataStore = require('./dataStore');
 var async = require('async');
 var logger;
 var EventEmitter = require('events').EventEmitter;
 
-exports.init = function(theLockerUrl, mongoCollection, mongo, config) {
+exports.init = function(theLockerUrl, mongo, _locker, config) {
     lconfig = config;
+    locker = _locker;
     logger = require('logger.js');
-    dataStore.init(mongoCollection, mongo);
+    dataStore.init(mongo, locker);
     exports.eventEmitter = new EventEmitter();
 }
 

--- a/Collections/Contacts/sync.js
+++ b/Collections/Contacts/sync.js
@@ -13,14 +13,12 @@ var lconfig;
 var dataStore = require('./dataStore');
 var async = require('async');
 var logger;
-var EventEmitter = require('events').EventEmitter;
 
 exports.init = function(theLockerUrl, mongo, _locker, config) {
     lconfig = config;
     locker = _locker;
     logger = require('logger.js');
     dataStore.init(mongo, locker);
-    exports.eventEmitter = new EventEmitter();
 }
 
 // TODO: this can be cleaned up further, the information is mostly captured in dataMap
@@ -84,7 +82,8 @@ function getContacts(type, endpoint, svcID, callback, offset) {
         if(body.length == 0) return callback();
         async.forEachSeries(body, function(contact, cb) {
             dataStore.addData(type, contact, cb);
-        }, function(){
+        }, function(err) {
+            if(err) return callback(err);
             getContacts(type, endpoint, svcID, callback, offset+500);
         });
     });

--- a/Collections/Links/api.js
+++ b/Collections/Links/api.js
@@ -1,0 +1,163 @@
+var dataStore = require('./dataStore');
+var path = require('path');
+var fs = require('fs');
+var locker = require('locker');
+var logger = require('logger');
+var crypto = require('crypto');
+var request = require('request');
+var url = require('url');
+
+module.exports = function(app, lockerInfo, prefix) {
+
+  locker.initClient(lockerInfo);
+
+  app.get('/state', function(req, res) {
+    dataStore.getTotalLinks(function(err, countInfo) {
+      if(err) return res.send(err, 500);
+      dataStore.getLastObjectID(function(err, lastObject) {
+        if(err) return res.send(err, 500);
+        var objId = '000000000000000000000000';
+        if (lastObject) objId = lastObject._id.toHexString();
+        var updated = Date.now();
+        try {
+          var js = JSON.parse(path.join(lockerInfo.workingDirectory, fs.readFileSync('state.json')));
+          if(js && js.updated) updated = js.updated;
+        } catch(E) {}
+        res.send({ready:1, count:countInfo, updated:updated, lastId:objId});
+      });
+    });
+  });
+
+
+  app.get('/search', function(req, res) {
+    if (!req.query.q) return res.send([]);
+    var u = url.parse(locker.lockerBase + '/Me/search/query');
+    u.query = req.query;
+    u.query.type = 'link';
+    u.query.sort = 'true'; // default sorted
+    // pretty much just dumb proxy it at this point
+    request({url:url.format(u)}, function(err, resp, body){
+      if(err || !body) return res.send(err, 500);
+      res.writeHead(200, {'content-type' : 'application/json'});
+      res.write(body);
+      res.end();
+    });
+  });
+
+  app.get('/since', function(req, res) {
+    if (!req.query.id) return res.send([]);
+    var results = [];
+    dataStore.getSince(req.query.id, function(link) {
+      results.push(link);
+    }, function() {
+      async.forEachSeries(results, function(link, callback) {
+        if (!link) return;
+        link.encounters = [];
+        dataStore.getEncounters({'link':link.link}, function(encounter) {
+          link.encounters.push(encounter);
+        }, function() {
+          callback();
+        });
+      }, function() {
+        var sorted = results.sort(function(lh, rh) {
+          return rh.at - lh.at;
+        });
+        res.send(sorted);
+      });
+    });
+  });
+
+
+  // expose way to get raw links and encounters
+  app.get('/', function(req, res) {
+    var full = isFull(req.query.full);
+    var fullResults = [];
+    var results = [];
+    var options = {sort: {at: -1}};
+    if(!req.query.all) options.limit = 20; // default 20 unless all is set
+    if (req.query.limit) options.limit = parseInt(req.query.limit);
+    if (req.query.offset) options.offset = parseInt(req.query.offset);
+    var deleteLink = false;
+    if (req.query.fields) {
+      try {
+        options.fields = JSON.parse(req.query.fields);
+        // we need the link field for merging encounters and links objects
+        // so get it, but flag it for deletion if not requested
+        if(!options.fields.hasOwnProperty('link') || options.fields.link == 0) {
+          options.fields.link = 1;
+          deleteLink = true;
+        }
+      } catch(E) {}
+    }
+    var ndx = {};
+    if(req.query.stream == 'true') {
+        res.writeHead(200, {'content-type' : 'application/jsonstream'});
+        options = {}; // exclusive
+    }
+    dataStore.getLinks(options, function(item) {
+      if(req.query.stream == 'true') return res.write(JSON.stringify(item)+'\n');
+      if(full) item.encounters = [];
+      ndx[item.link] = item;
+      // delete the link field if it wasn't requested
+      if(deleteLink) delete item.link;
+      results.push(item);
+    }, function(err) {
+      if(err) logger.error(err);
+      if(req.query.stream == 'true') return res.end();
+      if(full) {
+        var arg = {link: {$in: Object.keys(ndx)}};
+        if(options.fields) {
+          arg.fields = {};
+          // extract only encounter.* fields
+          for(var i in options.fields) {
+            if(i.length > 11 && i.substring(0,11) === 'encounters.') arg.fields[i.substring(11)] = options.fields[i];
+          }
+          // we need the link field for merging encounters and links objects
+          // so get it, but flag it for deletion if not requested
+          if(!arg.fields.hasOwnProperty('link') || arg.fields.link == 0) {
+            arg.fields.link = 1;
+            deleteLink = true;
+          }
+        }
+        dataStore.getEncounters(arg, function(encounter) {
+          ndx[encounter.link].encounters.push(encounter);
+         // delete the link field if it wasn't requested
+          if(deleteLink) delete encounter.link;
+        }, function() {
+          res.send(results);
+        });
+      } else {
+        return res.send(results);
+      }
+    });
+  });
+
+  // expose way to get the list of encounters from a link id
+  app.get('/encounters/:id', function(req, res) {
+    var encounters = [];
+    dataStore.get(req.param('id'), function(err, doc) {
+      if(err || !doc || !doc.link) return res.send(encounters);
+      dataStore.getEncounters({link: doc.link}, function(e){ encounters.push(e); }, function(err){ res.send(encounters); });
+    });
+  });
+
+  app.get('/id/:id', function(req, res, next) {
+    dataStore.get(req.param('id'), function(err, doc) {
+      if(err || !doc) return res.send(err, 500);
+      if(!doc.id) doc.id = crypto.createHash('md5').update(doc.link).digest('hex'); // older links are missing id, meh
+      if(!isFull(req.query.full)) return res.send(doc);
+      doc.encounters = [];
+      dataStore.getEncounters({link: doc.link}, function(e){ doc.encounters.push(e); }, function(err) { res.send(doc); });
+    });
+  });
+
+  locker.connectToMongo(function(mongo) {
+    // initialize all our libs
+    dataStore.init(mongo.collections.link, mongo.collections.encounter, mongo.collections.queue, mongo, logger);
+    // callback();
+  });
+}
+
+function isFull(full) {
+  return (full === true || full === "true" || full == 1);
+}

--- a/Collections/Links/api.js
+++ b/Collections/Links/api.js
@@ -7,7 +7,7 @@ var crypto = require('crypto');
 var request = require('request');
 var url = require('url');
 
-module.exports = function(app, lockerInfo, prefix) {
+module.exports = function(app, lockerInfo) {
 
   locker.initClient(lockerInfo);
 

--- a/Collections/Links/api.js
+++ b/Collections/Links/api.js
@@ -13,7 +13,7 @@ module.exports = function(app, lockerInfo) {
 
   locker.connectToMongo(function(mongo) {
     // initialize all our libs
-    dataStore.init(mongo.collections.link, mongo.collections.encounter, mongo.collections.queue, mongo, logger);
+    dataStore.init(mongo, locker);
     // TODO: this is a race condition. The routes will be added before the dataStore is initialized
     // callback();
   });
@@ -59,7 +59,7 @@ module.exports = function(app, lockerInfo) {
   });
 
   // expose way to get raw links and encounters
-  app.get('/', function(req, res) {
+  app.get('', function(req, res) {
     var full = isFull(req.query.full);
     var fullResults = [];
     var results = [];

--- a/Collections/Links/dataIn.js
+++ b/Collections/Links/dataIn.js
@@ -10,10 +10,10 @@ var debug = false;
 
 var dataStore, locker, logger;
 // internally we need these for happy fun stuff
-exports.init = function(l, dStore, log){
+exports.init = function(_locker, dStore, log) {
     dataStore = dStore;
-    locker = l;
-    logger = log;
+    locker = _locker;
+    logger = require("logger");
 }
 
 // manually walk and reindex all possible link sources

--- a/Collections/Links/dataStore.js
+++ b/Collections/Links/dataStore.js
@@ -34,7 +34,7 @@ exports.clear = function(callback) {
     });
 }
 
-exports.getTotalLinks = function(callback) {
+exports.getTotalCount = function(callback) {
     linkCollection.count(callback);
 }
 exports.getTotalEncounters = function(callback) {

--- a/Collections/Links/dataStore.js
+++ b/Collections/Links/dataStore.js
@@ -10,47 +10,58 @@ var logger;
 var fs = require('fs');
 var lutil = require('lutil');
 var lmongoutil = require("lmongoutil");
+var CollectionDataStore = require('collectionDataStore');
 
 // in the future we'll probably need a visitCollection too
 var linkCollection, encounterCollection, queueCollection, db;
+var linkCDS = new CollectionDataStore();
+var encounterCDS = new CollectionDataStore();
+var queueCDS = new CollectionDataStore();
 
-exports.init = function(lCollection, eCollection, qCollection, mongo, logger) {
+exports.init = function(mongo, locker) {
     db = mongo.dbClient;
-    linkCollection = lCollection;
+    logger = require("logger");
+
+    linkCDS.init(mongo, 'link', locker);
+    encounterCDS.init(mongo, 'encounter', locker);
+    queueCDS.init(mongo, 'queue', locker);
+
+    linkCollection = mongo.collections.link;
+    encounterCollection = mongo.collections.encounter;
+    queueCollection = mongo.collections.queue;
+
     linkCollection.ensureIndex({"link":1},{unique:true},function() {});
     linkCollection.ensureIndex({"id":1},{unique:true},function() {});
-    encounterCollection = eCollection;
+
     encounterCollection.ensureIndex({"link":1},{background:true},function() {});
     encounterCollection.ensureIndex({"orig":1},{background:true},function() {});
     encounterCollection.ensureIndex({"_hash":1},{background:true},function() {});
-    queueCollection = qCollection;
 }
 
 exports.clear = function(callback) {
-    linkCollection.drop(function() {
-        encounterCollection.drop(function() {
-            queueCollection.drop(callback);
-        });
+  linkCDS.clear(function() {
+    encounterCDS.clear(function() {
+      queueCDS.clear(callback);
     });
+  });
 }
 
-exports.getTotalCount = function(callback) {
-    linkCollection.count(callback);
-}
-exports.getTotalEncounters = function(callback) {
-    encounterCollection.count(callback);
-}
+exports.getTotalCount = linkCDS.getTotalCount;
+exports.getTotalEncounters = encounterCDS.getTotalCount;
+exports.getSince = linkCDS.getSince;
+exports.getLastObjectID = linkCDS.getLastObjectID;
+exports.get = linkCDS.get;
 
 exports.enqueue = function(obj, callback) {
-    queueCollection.findAndModify({"text":obj.text}, [['_id','asc']], {$set:{'obj' : obj, 'at' : Date.now()}}, {safe:true, upsert:true, new: true}, callback);
+  queueCollection.findAndModify({"text":obj.text}, [['_id','asc']], {$set:{'obj' : obj, 'at' : Date.now()}}, {safe:true, upsert:true, new: true}, callback);
 }
 
 exports.dequeue = function(obj, callback) {
-    queueCollection.remove({"text":obj.text}, callback);
+  queueCollection.remove({"text":obj.text}, callback);
 }
 
 exports.fetchQueue = function(callback) {
-    queueCollection.find().sort({at: -1}).toArray(callback);
+  queueCollection.find().sort({at: -1}).toArray(callback);
 }
 
 // handy to check all the original urls we've seen to know if we already have a link expanded/done
@@ -70,14 +81,14 @@ exports.getLinks = function(arg, cbEach, cbDone) {
     if(workaround == false)
     { // this is the strangest thing, temp workaround till https://github.com/christkv/node-mongodb-native/issues/447
         workaround = true;
-        findWrap({},{limit:1},linkCollection,function(){},function(){
+        linkCDS.findWrap({},{limit:1},function(){},function(){
             exports.getLinks(arg, cbEach, cbDone);
         });
         return;
     }
     var f = (arg.link)?{link:arg.link}:{};
     delete arg.id;
-    findWrap(f,arg,linkCollection,cbEach,cbDone);
+    linkCDS.findWrap(f,arg,cbEach,cbDone);
 }
 
 exports.getFullLink = function(id, cbDone) {
@@ -92,63 +103,16 @@ exports.getEncounters = function(arg, cbEach, cbDone) {
     delete arg.id;
     delete arg.network;
     delete arg.link;
-    findWrap(f,arg,encounterCollection,cbEach,cbDone)
+    encounterCDS.findWrap(f,arg,cbEach,cbDone)
 }
 
-exports.getSince = function(objId, cbEach, cbDone) {
-    findWrap({"_id":{"$gt":lmongoutil.ObjectID(objId)}}, {sort:{_id:-1}}, linkCollection, cbEach, cbDone);
-}
-
-exports.getLastObjectID = function(cbDone) {
-    linkCollection.find({}, {fields:{_id:1}, limit:1, sort:{_id:-1}}).nextObject(cbDone);
-}
-
-exports.get = function(id, callback) {
-    var or = []
-    try {
-        or.push({_id:new db.bson_serializer.ObjectID(id)});
-    }catch(E){}
-    or.push({id:id});
-    linkCollection.findOne({$or:or}, callback);
-}
-
-function findWrap(a,b,c,cbEach,cbDone){
-    var cursor = (b.fields) ? c.find(a, b) : c.find(a);
-    if (b.sort) cursor.sort(b.sort);
-    if (b.limit) cursor.limit(b.limit);
-    if (b.offset) cursor.skip(b.offset);
-//    cursor.count(function(err,c){console.error("COUNT "+c)});
-    var total = 0;
-    cursor.each(function(err, item) {
-        if (item != null) {
-            total++;
-            cbEach(item);
-        } else {
-//            cursor.count(function(err,c){console.error("TOTAL "+total+" COUNT "+c)});
-            cbDone();
-        }
-    });
-}
-
-var writeTimer = false;
-function updateState()
-{
-    if (writeTimer) {
-        clearTimeout(writeTimer);
-    }
-    writeTimer = setTimeout(function() {
-        try {
-            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:Date.now()}));
-        } catch (E) {}
-    }, 5000);
-}
 
 // insert new (fully normalized) link, ignore or replace if it already exists?
 // {link:"http://foo.com/bar", title:"Foo", text:"Foo bar is delicious.", favicon:"http://foo.com/favicon.ico"}
 exports.addLink = function(link, callback) {
 //    logger.verbose("addLink: "+JSON.stringify(link));
     linkCollection.findAndModify({"link":link.link}, [['_id','asc']], {$set:link}, {safe:true, upsert:true, new: true}, callback);
-    updateState();
+    linkCDS.updateState();
 }
 
 exports.updateLinkAt = function(link, at, callback) {

--- a/Collections/Links/links.js
+++ b/Collections/Links/links.js
@@ -93,7 +93,6 @@ if (lconfig.airbrakeKey) {
 // Process the startup JSON object
 process.stdin.resume();
 process.stdin.on('data', function(data) {
-  console.error("DEBUG: links - lockerInfo", lockerInfo);
     lockerInfo = JSON.parse(data);
     locker.initClient(lockerInfo);
     locker.lockerBase = lockerInfo.lockerUrl;

--- a/Collections/Links/links.js
+++ b/Collections/Links/links.js
@@ -31,67 +31,6 @@ var app = express.createServer(connect.bodyParser());
 
 app.set('views', __dirname);
 
-app.get('/state', function(req, res) {
-    dataStore.getTotalLinks(function(err, countInfo) {
-        if(err) return res.send(err, 500);
-        dataStore.getLastObjectID(function(err, lastObject) {
-            if(err) return res.send(err, 500);
-            var objId = "000000000000000000000000";
-            if (lastObject) objId = lastObject._id.toHexString();
-            var updated = Date.now();
-            try {
-                var js = JSON.parse(fs.readFileSync('state.json'));
-                if(js && js.updated) updated = js.updated;
-            } catch(E) {}
-            res.send({ready:1, count:countInfo, updated:updated, lastId:objId});
-        });
-    });
-});
-
-app.get('/search', function(req, res) {
-    if (!req.query.q) {
-        res.send([]);
-        return;
-    }
-    var u = url.parse(locker.lockerBase+"/Me/search/query");
-    u.query = req.query;
-    u.query.type = "link";
-    u.query.sort = "true"; // default sorted
-    // pretty much just dumb proxy it at this point
-    request({url:url.format(u)}, function(err, resp, body){
-        if(err || !body) return res.send(err, 500);
-        res.writeHead(200, {'content-type' : 'application/json'});
-        res.write(body);
-        res.end();
-    });
-});
-
-app.get("/since", function(req, res) {
-    if (!req.query.id) {
-        return res.send([]);
-    }
-
-    var results = [];
-    dataStore.getSince(req.query.id, function(link) {
-        results.push(link);
-    }, function() {
-        async.forEachSeries(results, function(link, callback) {
-            if (!link) return;
-            link.encounters = [];
-            dataStore.getEncounters({"link":link.link}, function(encounter) {
-                link.encounters.push(encounter);
-            }, function() {
-                callback();
-            });
-        }, function() {
-            var sorted = results.sort(function(lh, rh) {
-                return rh.at - lh.at;
-            });
-            res.send(sorted);
-        });
-   });
-});
-
 app.get('/update', function(req, res) {
     dataIn.reIndex(locker, function(){
         res.writeHead(200);
@@ -138,105 +77,11 @@ function genericApi(name,f)
     });
 }
 
-// expose way to get raw links and encounters
-app.get('/', function(req, res) {
-    var full = isFull(req.query.full);
-    var fullResults = [];
-    var results = [];
-    var options = {sort:{"at":-1}};
-    if(!req.query["all"]) options.limit = 20; // default 20 unless all is set
-    if (req.query.limit) {
-        options.limit = parseInt(req.query.limit);
-    }
-    if (req.query.offset) {
-        options.offset = parseInt(req.query.offset);
-    }
-    var deleteLink = false;
-    if (req.query.fields) {
-        try {
-            options.fields = JSON.parse(req.query.fields);
-            // we need the link field for merging encounters and links objects
-            // so get it, but flag it for deletion if not requested
-            if(!options.fields.hasOwnProperty('link') || options.fields.link == 0) {
-                options.fields.link = 1;
-                deleteLink = true;
-            }
-        } catch(E) {}
-    }
-    var ndx = {};
-    if(req.query['stream'] == "true")
-    {
-        res.writeHead(200, {'content-type' : 'application/jsonstream'});
-        options = {}; // exclusive
-    }
-    dataStore.getLinks(options, function(item) {
-        if(req.query['stream'] == "true") return res.write(JSON.stringify(item)+'\n');
-        if(full)
-            item.encounters = [];
-        ndx[item.link] = item;
-        if(deleteLink) // delete the link field if it wasn't requested
-            delete item.link;
-        results.push(item);
-    }, function(err) {
-        if(err) logger.error(err);
-        if(req.query['stream'] == "true") return res.end();
-        if(full) {
-            var arg = {"link":{$in: Object.keys(ndx)}};
-            if(options.fields) {
-                arg.fields = {};
-                // extract only encounter.* fields
-                for(var i in options.fields) {
-                    if(i.length > 11 && i.substring(0,11) === 'encounters.')
-                        arg.fields[i.substring(11)] = options.fields[i];
-                }
-                // we need the link field for merging encounters and links objects
-                // so get it, but flag it for deletion if not requested
-                if(!arg.fields.hasOwnProperty('link') || arg.fields.link == 0) {
-                    arg.fields.link = 1;
-                    deleteLink = true;
-                }
-            }
-            dataStore.getEncounters(arg, function(encounter) {
-                ndx[encounter.link].encounters.push(encounter);
-                if(deleteLink) // delete the link field if it wasn't requested
-                    delete encounter.link;
-            }, function() {
-                res.send(results);
-            });
-        } else {
-            return res.send(results);
-        }
-    });
-});
-
-// expose way to get the list of encounters from a link id
-app.get('/encounters/:id', function(req, res) {
-    var encounters = [];
-    dataStore.get(req.param('id'), function(err, doc) {
-        if(err || !doc || !doc.link) return res.send(encounters);
-        dataStore.getEncounters({link: doc.link}, function(e){ encounters.push(e); }, function(err){ res.send(encounters); });
-    });
-});
-
-app.get('/id/:id', function(req, res, next) {
-    dataStore.get(req.param('id'), function(err, doc) {
-        if(err || !doc) return res.send(err, 500);
-        if(!doc.id) doc.id = crypto.createHash('md5').update(doc.link).digest('hex'); // older links are missing id, meh
-        if(!isFull(req.query.full)) return res.send(doc);
-        doc.encounters = [];
-        dataStore.getEncounters({link: doc.link}, function(e){ doc.encounters.push(e); }, function(err) { res.send(doc); });
-    });
-});
-
 // expose all utils
 for(var f in util)
 {
     if(f == 'init') continue;
     genericApi('/'+f,util[f]);
-}
-
-function isFull(full) {
-    return (full === true || full === "true" || full == 1);
 }
 
 // catch exceptions, links are very garbagey
@@ -248,10 +93,11 @@ if (lconfig.airbrakeKey) {
 // Process the startup JSON object
 process.stdin.resume();
 process.stdin.on('data', function(data) {
+  console.error("DEBUG: links - lockerInfo", lockerInfo);
     lockerInfo = JSON.parse(data);
     locker.initClient(lockerInfo);
     locker.lockerBase = lockerInfo.lockerUrl;
-    if (!lockerInfo || !lockerInfo['workingDirectory']) {
+    if (!lockerInfo || !lockerInfo.workingDirectory) {
         process.stderr.write('Was not passed valid startup information.'+data+'\n');
         process.exit(1);
     }

--- a/Collections/Links/links.js
+++ b/Collections/Links/links.js
@@ -106,7 +106,7 @@ process.stdin.on('data', function(data) {
 
     locker.connectToMongo(function(mongo) {
         // initialize all our libs
-        dataStore.init(mongo.collections.link, mongo.collections.encounter, mongo.collections.queue, mongo, logger);
+        dataStore.init(mongo, locker);
         dataIn.init(locker, dataStore, logger);
         app.listen(0, 'localhost', function() {
             var returnedInfo = {port: app.address().port};

--- a/Collections/Photos/api.js
+++ b/Collections/Photos/api.js
@@ -1,0 +1,91 @@
+var fs = require('fs');
+var path = require('path');
+var locker = require('locker');
+var logger = require('logger');
+var request = require('request');
+var url = require('url');
+
+module.exports = function(app, lockerInfo) {
+
+  var dataStore = require(path.join(lockerInfo.sourceDirectory, 'dataStore.js'));
+  locker.initClient(lockerInfo);
+
+  locker.connectToMongo(function(mongo) {
+    // initialize all our libs
+    dataStore.init(mongo, locker, lockerInfo);
+    // TODO: this is a race condition. The routes will be added before the dataStore is initialized
+    // callback();
+  });
+
+  app.get('/state', function(req, res) {
+    dataStore.state(function(err, state) {
+      if(err) return res.send(err, 500)
+      res.send(state);
+    });
+  });
+
+  app.get('', function(req, res) {
+    var fields = {};
+    if (req.query.fields) {
+      try {
+        fields = JSON.parse(req.query.fields);
+      } catch(E) {}
+    }
+    dataStore.getAll(fields, function(err, cursor) {
+      if(!req.query['all']) cursor.limit(20); // default 20 unless all is set
+      if(req.query['limit']) cursor.limit(parseInt(req.query['limit']));
+      if(req.query['offset']) cursor.skip(parseInt(req.query['offset']));
+      if(req.query['stream'] == 'true') {
+        res.writeHead(200, {'content-type' : 'application/jsonstream'});
+        cursor.each(function(err, object){
+          if (err) logger.error(err); // only useful here for logging really
+          if (!object) return res.end();
+          res.write(JSON.stringify(object)+'\n');
+        });
+      } else {
+        cursor.toArray(function(err, items) {
+          res.send(items);
+        });
+      }
+    });
+  });
+
+  app.get('/since', function(req, res) {
+    if (!req.query.id) return res.send([]);
+    var results = [];
+    dataStore.getSince(req.query.id, function(item) {
+      results.push(item);
+    }, function() {
+      res.send(results);
+    });
+  });
+
+  app.get('/id/:id', function(req, res, next) {
+    dataStore.get(req.param('id'), function(err, doc) {
+      if(err) return res.send(err, 500);
+      res.send(doc);
+    })
+  });
+
+  app.get('/image/:photoId', function(req, res) {
+    getImageHelper(req.params.photoId, 'url', req.query.proxy, res);
+  });
+
+  app.get('/thumbnail/:photoId', function(req, res) {
+    getImageHelper(req.params.photoId, 'thumbnail', req.query.proxy, res);
+  });
+
+  function getImageHelper(id, field, proxy, res) {
+    if (!id) return res.send('No photo id supplied', 500);
+
+    dataStore.get(id, function(error, data) {
+      if (error || !data || !data[field]) return res.send(error||'no data', 500);
+      res.header('Access-Control-Allow-Origin', '*');
+      res.header('Access-Control-Allow-Headers', 'X-Requested-With');
+      if(proxy) return request.get({url:data[field]}).pipe(res);
+      res.writeHead(302, {'location':data[field]});
+      return res.end('');
+    });
+  }
+
+}

--- a/Collections/Photos/dataIn.js
+++ b/Collections/Photos/dataIn.js
@@ -1,7 +1,8 @@
 var dataStore = require('./dataStore');
 var url = require('url');
-var logger = require('logger');
+var logger, lconfig;
 var async = require('async');
+var request = require('request');
 
 var dataHandlers = {
   "timeline/twitter": processTwitter,
@@ -13,6 +14,12 @@ var dataHandlers = {
   "photo/instagram": processInstagram,
   "feed/instagram": doNothing,
   "post/tumblr": processTumblr
+}
+
+// TODO: tech debt, clean this up with logger and lconfig fixes!
+exports.init = function() {
+  logger = require('logger');
+  lconfig = require('lconfig');
 }
 
 function doNothing(svcId, data, cb) {

--- a/Collections/Photos/dataIn.js
+++ b/Collections/Photos/dataIn.js
@@ -1,0 +1,246 @@
+var dataStore = require('./dataStore');
+var url = require('url');
+var async = require('async');
+
+var dataHandlers = {
+  "timeline/twitter": processTwitter,
+  "tweets/twitter": processTwitter,
+  "checkin/foursquare": processFoursquare,
+  "photo/twitpic": processTwitPic,
+  "photo/facebook": processFacebook,
+  "photo/flickr": processFlickr,
+  "photo/instagram": processInstagram,
+  "feed/instagram": doNothing,
+  "post/tumblr": processTumblr
+}
+
+function doNothing(svcId, data, cb) {
+    cb();
+}
+
+function processTwitPic(svcId, data, cb) {
+    if (!data.id) {
+        cb("The twitpic data was invalid");
+        return;
+    }
+
+    var photoInfo = {};
+    photoInfo.url = lconfig.lockerBase + "/Me/" + svcId + "/full/" + data.id;
+    if (data.txt) photoInfo.title = data.txt;
+    if (data.thumb) photoInfo.thumbnail = data.thumb;
+    photoInfo.timestamp = Date.now();
+
+    photoInfo.sources = [{service:svcId, id:data.id, data:data}];
+
+    dataStore.saveCommonPhoto(photoInfo, cb);
+}
+
+
+var fbProfile;
+function getFacebookProfile(callback) {
+    if(fbProfile) return callback();
+    request.get({uri:lconfig.lockerBase + '/synclets/facebook/get_profile', json:true}, function(err, resp, profile) {
+        fbProfile = profile;
+        callback();
+    });
+}
+function processFacebook(svcId, data, cb) {
+    getFacebookProfile(function() {
+        var photoInfo = {};
+
+        // Gotta have a url minimum
+        if (!data.source) {
+            cb("The data did not have a source");
+            return;
+        }
+        photoInfo.url = data.source;
+        // TODO:  For now we're just taking the smallest one, there's also an icon field
+        if (data.images) photoInfo.thumbnail = data.images[data.images.length - 1].source;
+        if (data.width) photoInfo.width = data.width;
+        if (data.height) photoInfo.height = data.height;
+        if (data.created_time) photoInfo.timestamp = data.created_time*1000;
+        if (data.name) photoInfo.title = data.name;
+        if (data.link) photoInfo.sourceLink = data.link;
+
+        photoInfo.sources = [{service:svcId, id:data.id, data:data}];
+        photoInfo.me = (data.from.id == fbProfile.id);
+        dataStore.saveCommonPhoto(photoInfo, cb);
+    });
+}
+
+function processInstagram(svcId, data, cb) {
+    var photoInfo = {};
+
+    // Gotta have a url minimum
+    if (!data.images || !data.images.standard_resolution) {
+        cb("The data did not have a source");
+        return;
+    }
+    photoInfo.url = data.images.standard_resolution.url;
+    photoInfo.width = data.images.standard_resolution.width;
+    photoInfo.height = data.images.standard_resolution.height;
+    if (data.images.thumbnail) photoInfo.thumbnail = data.images.thumbnail.url;
+    if (data.created_time) photoInfo.timestamp = data.created_time*1000;
+    if (data.caption) photoInfo.title = data.caption.text;
+    if (data.link) photoInfo.sourceLink = data.link;
+
+    photoInfo.sources = [{service:svcId, id:data.id, data:data}];
+
+    dataStore.saveCommonPhoto(photoInfo, cb);
+}
+
+function processTumblr(svcId, data, cb) {
+    var photoInfo = {};
+
+    // Gotta have a url minimum
+    if (data.type != "photo" || !data.photos || !data.photos[0] || !data.photos[0].original_size || !data.photos[0].original_size.url) {
+        return cb();
+    }
+    var photo = data.photos[0];
+    photoInfo.url = photo.original_size.url;
+    photoInfo.width = photo.original_size.width;
+    photoInfo.height = photo.original_size.height;
+    var ndx = {};
+    if(photo.alt_sizes) photo.alt_sizes.forEach(function(size){
+        ndx[size.height] = size.url;
+    });
+    if (ndx["75"]) photoInfo.thumbnail = ndx["75"];
+    if (data.timestamp) photoInfo.timestamp = data.timestamp*1000;
+    if (data.caption) photoInfo.title = data.caption; // TODO, strip html
+    if (data.post_url) photoInfo.sourceLink = data.post_url;
+
+    photoInfo.sources = [{service:svcId, id:data.id, data:data}];
+
+    dataStore.saveCommonPhoto(photoInfo, cb);
+}
+
+function getFlickrItem(photoObject, field) {
+    return photoObject[field + '_o'] || photoObject[field + '_l'] || photoObject[field + '_z'] ||
+           photoObject[field + '_m'] || photoObject[field + '_s'] || photoObject[field + '_t'];
+}
+
+function processFlickr(svcId, data, cb) {
+    if (!data.id || !getFlickrItem(data, 'url')) {
+        cb("The flickr data was invalid");
+        return;
+    }
+
+    var photoInfo = {};
+    photoInfo.url = getFlickrItem(data, 'url');
+    photoInfo.height = getFlickrItem(data, 'height');
+    photoInfo.width = getFlickrItem(data, 'width');
+    if (data.title) photoInfo.title = data.title
+    if (data.url_t) photoInfo.thumbnail = data.url_t;
+    if (data.owner && data.id) photoInfo.sourceLink = "http://www.flickr.com/photos/" + data.owner + "/" + data.id + "/";
+    if (data.datetaken) {
+        var d = new Date(data.datetaken);
+        photoInfo.timestamp = d.getTime();
+    }
+
+    photoInfo.sources = [{service:svcId, id:data.id, data:data}];
+
+    dataStore.saveCommonPhoto(photoInfo, cb);
+
+}
+
+// pretty experimental! extract photos from your tweets using embedly :)
+function processTwitter(svcId, data, cb)
+{
+    logger.verbose('processTwitter!');
+    if(!data || !data.entities || !Array.isArray(data.entities.urls)) return cb();
+
+    async.forEach(data.entities.urls,function(u,callback){
+        if(!u || !u.url) return callback();
+        var embed = url.parse(lconfig.lockerBase+"/Me/links/embed");
+        var turl = (u.expanded_url) ? u.expanded_url : u.url;
+        logger.verbose('found twitter url:' + turl);
+        embed.query = {url:turl};
+        request.get({uri:url.format(embed), json:true},function(err,resp,js){
+            if(err || !js) return callback();
+            if(!js || !js.type || js.type != "photo" || !js.url) return callback();
+            logger.verbose('found twitter photo! ' +  turl);
+            var photoInfo = {};
+            photoInfo.url = js.url;
+            if (js.height) photoInfo.height = js.height;
+            if (js.width) photoInfo.width = js.width;
+            photoInfo.title = data.text;
+            if (js.thumbnail_url) photoInfo.thumbnail = js.thumbnail_url;
+            if (data.created_at) photoInfo.timestamp = new Date(data.created_at).getTime();
+            photoInfo.sourceLink = "http://twitter.com/#!/" + data.user.screen_name + "/status/" + data.id_str;
+
+            photoInfo.sources = [{service:svcId, id:data.id, data:data}];
+            dataStore.saveCommonPhoto(photoInfo, callback);
+        });
+    },function(){ // example: https://api.twitter.com/1/statuses/show/121716701338402817.json?include_entities=true
+        if(!Array.isArray(data.entities.media)) return cb();
+        async.forEach(data.entities.media,function(m,callback){
+            if(!m || !m.media_url) return callback();
+            var photoInfo = {};
+            photoInfo.url = m.media_url;
+            if (m.sizes.large) {
+                photoInfo.height = m.sizes.large.h;
+                photoInfo.width = m.sizes.large.w;
+            }
+            photoInfo.title = data.text;
+            if (data.created_at) photoInfo.timestamp = new Date(data.created_at).getTime();
+            photoInfo.sourceLink = "http://twitter.com/#!/" + data.user.screen_name + "/status/" + data.id_str;
+            photoInfo.sources = [{service:svcId, id:data.id, data:data}];
+            dataStore.saveCommonPhoto(photoInfo, callback);
+        },cb);
+    });
+}
+
+// look at all checkins, see if any contain attached photos
+function processFoursquare(svcId, data, cb)
+{
+    if(!data || !data.photos || !Array.isArray(data.photos.items)) return cb();
+    var photoInfo = {};
+
+    async.forEach(data.photos.items,function(photo,callback){
+        if(!photo || !photo.sizes || !Array.isArray(photo.sizes.items) || photo.sizes.items.length == 0) return callback();
+        photoInfo = {};
+        photoInfo.url = photo.sizes.items[0].url;
+        if (photo.sizes.items[0].height) photoInfo.height = photo.sizes.items[0].height;
+        if (photo.sizes.items[0].width) photoInfo.width = photo.sizes.items[0].width;
+        if (data.venue.name) photoInfo.title = data.venue.name;
+        photoInfo.thumbnail = photo.sizes.items[photo.sizes.items.length-2].url;
+        if (data.createdAt) photoInfo.timestamp = new Date(data.createdAt).getTime() * 1000;
+        photoInfo.sourceLink = "http://foursquare.com/user/" + photo.user.id + "/checkin/" + data.id;
+
+        photoInfo.sources = [{service:svcId, id:photo.id, data:data}];
+        dataStore.saveCommonPhoto(photoInfo, function(err, data) { photoInfo = data; callback(err);});
+    }, function(err) { cb(err, photoInfo); });
+}
+
+
+exports.addEvent = function(eventBody, callback) {
+    // TODO:  Handle the other actions appropiately
+    if (eventBody.action !== "new") {
+        callback(null, {});
+        return;
+    }
+    // Run the data processing
+    var idr = url.parse(eventBody.idr, true);
+    var svcId = idr.query["id"];
+    var type = idr.pathname.substr(1) + '/' + idr.host
+    var handler = dataHandlers[type];
+    if (!handler) {
+        logger.warn("unhandled "+type);
+        return callback();
+    }
+    handler(svcId, eventBody.data, callback);
+}
+
+exports.addData = function(svcId, type, allData, callback) {
+    if (callback === undefined) {
+        callback = function() {};
+    }
+    var handler = dataHandlers[type];
+    if (!handler) {
+        logger.warn("unhandled "+type);
+        return callback();
+    }
+    async.forEachSeries(allData,function(data,cb) {
+        handler(svcId, data, cb);
+    },callback);
+}

--- a/Collections/Photos/dataIn.js
+++ b/Collections/Photos/dataIn.js
@@ -1,5 +1,6 @@
 var dataStore = require('./dataStore');
 var url = require('url');
+var logger = require('logger');
 var async = require('async');
 
 var dataHandlers = {

--- a/Collections/Photos/dataStore.js
+++ b/Collections/Photos/dataStore.js
@@ -9,226 +9,26 @@
 
 var collection;
 var db;
-var lconfig;
 var lutil = require('lutil');
 var logger;
-var request = require("request");
 var crypto = require("crypto");
-var async = require("async");
-var url = require("url");
-var fs = require('fs');
 var url = require('url');
 var lmongoutil = require("lmongoutil");
 var locker;
 
-function processTwitPic(svcId, data, cb) {
-    if (!data.id) {
-        cb("The twitpic data was invalid");
-        return;
-    }
+var CollectionDataStore = require('collectionDataStore');
+var collectionDataStore = new CollectionDataStore();
 
-    var photoInfo = {};
-    photoInfo.url = lconfig.lockerBase + "/Me/" + svcId + "/full/" + data.id;
-    if (data.txt) photoInfo.title = data.txt;
-    if (data.thumb) photoInfo.thumbnail = data.thumb;
-    photoInfo.timestamp = Date.now();
+exports.init = function(mongo, _locker) {
+    locker = _locker;
+    collection = mongo.collections.photo;
+    collectionDataStore.init(mongo, 'photo', locker);
 
-    photoInfo.sources = [{service:svcId, id:data.id, data:data}];
-
-    saveCommonPhoto(photoInfo, cb);
+    db = mongo.dbClient;
+    logger = require("logger");
 }
 
-
-var fbProfile;
-function getFacebookProfile(callback) {
-    if(fbProfile) return callback();
-    request.get({uri:lconfig.lockerBase + '/synclets/facebook/get_profile', json:true}, function(err, resp, profile) {
-        fbProfile = profile;
-        callback();
-    });
-}
-function processFacebook(svcId, data, cb) {
-    getFacebookProfile(function() {
-        var photoInfo = {};
-
-        // Gotta have a url minimum
-        if (!data.source) {
-            cb("The data did not have a source");
-            return;
-        }
-        photoInfo.url = data.source;
-        // TODO:  For now we're just taking the smallest one, there's also an icon field
-        if (data.images) photoInfo.thumbnail = data.images[data.images.length - 1].source;
-        if (data.width) photoInfo.width = data.width;
-        if (data.height) photoInfo.height = data.height;
-        if (data.created_time) photoInfo.timestamp = data.created_time*1000;
-        if (data.name) photoInfo.title = data.name;
-        if (data.link) photoInfo.sourceLink = data.link;
-
-        photoInfo.sources = [{service:svcId, id:data.id, data:data}];
-        photoInfo.me = (data.from.id == fbProfile.id);
-        saveCommonPhoto(photoInfo, cb);
-    });
-}
-
-function processInstagram(svcId, data, cb) {
-    var photoInfo = {};
-
-    // Gotta have a url minimum
-    if (!data.images || !data.images.standard_resolution) {
-        cb("The data did not have a source");
-        return;
-    }
-    photoInfo.url = data.images.standard_resolution.url;
-    photoInfo.width = data.images.standard_resolution.width;
-    photoInfo.height = data.images.standard_resolution.height;
-    if (data.images.thumbnail) photoInfo.thumbnail = data.images.thumbnail.url;
-    if (data.created_time) photoInfo.timestamp = data.created_time*1000;
-    if (data.caption) photoInfo.title = data.caption.text;
-    if (data.link) photoInfo.sourceLink = data.link;
-
-    photoInfo.sources = [{service:svcId, id:data.id, data:data}];
-
-    saveCommonPhoto(photoInfo, cb);
-}
-
-function processTumblr(svcId, data, cb) {
-    var photoInfo = {};
-
-    // Gotta have a url minimum
-    if (data.type != "photo" || !data.photos || !data.photos[0] || !data.photos[0].original_size || !data.photos[0].original_size.url) {
-        return cb();
-    }
-    var photo = data.photos[0];
-    photoInfo.url = photo.original_size.url;
-    photoInfo.width = photo.original_size.width;
-    photoInfo.height = photo.original_size.height;
-    var ndx = {};
-    if(photo.alt_sizes) photo.alt_sizes.forEach(function(size){
-        ndx[size.height] = size.url;
-    });
-    if (ndx["75"]) photoInfo.thumbnail = ndx["75"];
-    if (data.timestamp) photoInfo.timestamp = data.timestamp*1000;
-    if (data.caption) photoInfo.title = data.caption; // TODO, strip html
-    if (data.post_url) photoInfo.sourceLink = data.post_url;
-
-    photoInfo.sources = [{service:svcId, id:data.id, data:data}];
-
-    saveCommonPhoto(photoInfo, cb);
-}
-
-function getFlickrItem(photoObject, field) {
-    return photoObject[field + '_o'] || photoObject[field + '_l'] || photoObject[field + '_z'] ||
-           photoObject[field + '_m'] || photoObject[field + '_s'] || photoObject[field + '_t'];
-}
-
-function processFlickr(svcId, data, cb) {
-    if (!data.id || !getFlickrItem(data, 'url')) {
-        cb("The flickr data was invalid");
-        return;
-    }
-
-    var photoInfo = {};
-    photoInfo.url = getFlickrItem(data, 'url');
-    photoInfo.height = getFlickrItem(data, 'height');
-    photoInfo.width = getFlickrItem(data, 'width');
-    if (data.title) photoInfo.title = data.title
-    if (data.url_t) photoInfo.thumbnail = data.url_t;
-    if (data.owner && data.id) photoInfo.sourceLink = "http://www.flickr.com/photos/" + data.owner + "/" + data.id + "/";
-    if (data.datetaken) {
-        var d = new Date(data.datetaken);
-        photoInfo.timestamp = d.getTime();
-    }
-
-    photoInfo.sources = [{service:svcId, id:data.id, data:data}];
-
-    saveCommonPhoto(photoInfo, cb);
-
-}
-
-// pretty experimental! extract photos from your tweets using embedly :)
-function processTwitter(svcId, data, cb)
-{
-    logger.verbose('processTwitter!');
-    if(!data || !data.entities || !Array.isArray(data.entities.urls)) return cb();
-
-    async.forEach(data.entities.urls,function(u,callback){
-        if(!u || !u.url) return callback();
-        var embed = url.parse(lconfig.lockerBase+"/Me/links/embed");
-        var turl = (u.expanded_url) ? u.expanded_url : u.url;
-        logger.verbose('found twitter url:' + turl);
-        embed.query = {url:turl};
-        request.get({uri:url.format(embed), json:true},function(err,resp,js){
-            if(err || !js) return callback();
-            if(!js || !js.type || js.type != "photo" || !js.url) return callback();
-            logger.verbose('found twitter photo! ' +  turl);
-            var photoInfo = {};
-            photoInfo.url = js.url;
-            if (js.height) photoInfo.height = js.height;
-            if (js.width) photoInfo.width = js.width;
-            photoInfo.title = data.text;
-            if (js.thumbnail_url) photoInfo.thumbnail = js.thumbnail_url;
-            if (data.created_at) photoInfo.timestamp = new Date(data.created_at).getTime();
-            photoInfo.sourceLink = "http://twitter.com/#!/" + data.user.screen_name + "/status/" + data.id_str;
-
-            photoInfo.sources = [{service:svcId, id:data.id, data:data}];
-            saveCommonPhoto(photoInfo, callback);
-        });
-    },function(){ // example: https://api.twitter.com/1/statuses/show/121716701338402817.json?include_entities=true
-        if(!Array.isArray(data.entities.media)) return cb();
-        async.forEach(data.entities.media,function(m,callback){
-            if(!m || !m.media_url) return callback();
-            var photoInfo = {};
-            photoInfo.url = m.media_url;
-            if (m.sizes.large) {
-                photoInfo.height = m.sizes.large.h;
-                photoInfo.width = m.sizes.large.w;
-            }
-            photoInfo.title = data.text;
-            if (data.created_at) photoInfo.timestamp = new Date(data.created_at).getTime();
-            photoInfo.sourceLink = "http://twitter.com/#!/" + data.user.screen_name + "/status/" + data.id_str;
-            photoInfo.sources = [{service:svcId, id:data.id, data:data}];
-            saveCommonPhoto(photoInfo, callback);
-        },cb);
-    });
-}
-
-// look at all checkins, see if any contain attached photos
-function processFoursquare(svcId, data, cb)
-{
-    if(!data || !data.photos || !Array.isArray(data.photos.items)) return cb();
-    var photoInfo = {};
-
-    async.forEach(data.photos.items,function(photo,callback){
-        if(!photo || !photo.sizes || !Array.isArray(photo.sizes.items) || photo.sizes.items.length == 0) return callback();
-        photoInfo = {};
-        photoInfo.url = photo.sizes.items[0].url;
-        if (photo.sizes.items[0].height) photoInfo.height = photo.sizes.items[0].height;
-        if (photo.sizes.items[0].width) photoInfo.width = photo.sizes.items[0].width;
-        if (data.venue.name) photoInfo.title = data.venue.name;
-        photoInfo.thumbnail = photo.sizes.items[photo.sizes.items.length-2].url;
-        if (data.createdAt) photoInfo.timestamp = new Date(data.createdAt).getTime() * 1000;
-        photoInfo.sourceLink = "http://foursquare.com/user/" + photo.user.id + "/checkin/" + data.id;
-
-        photoInfo.sources = [{service:svcId, id:photo.id, data:data}];
-        saveCommonPhoto(photoInfo, function(err, data) { photoInfo = data; callback(err);});
-    }, function(err) { cb(err, photoInfo); });
-}
-
-var writeTimer = false;
-function updateState()
-{
-    if (writeTimer) {
-        clearTimeout(writeTimer);
-    }
-    writeTimer = setTimeout(function() {
-        try {
-            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:Date.now()}));
-        } catch (E) {}
-    }, 5000);
-}
-
-function saveCommonPhoto(photoInfo, cb) {
+exports.saveCommonPhoto = function(photoInfo, cb) {
     // This is the only area we do basic matching on right now.  We'll do more later
     var query = [{url:photoInfo.url}];
     if (photoInfo.title) {
@@ -237,14 +37,13 @@ function saveCommonPhoto(photoInfo, cb) {
     if (!photoInfo.id) photoInfo.id = createId(photoInfo.url, photoInfo.name);
     collection.findAndModify({$or:query}, [['_id','asc']], {$set:photoInfo}, {safe:true, upsert:true, new: true}, function(err, doc) {
         if (!err) {
-            updateState();
+            collectionDataStore.updateState();
             locker.ievent(lutil.idrNew("photo", "photos", doc.id), doc);
             return cb(undefined, doc);
         }
         cb(err);
     });
 }
-
 /**
 * Common function to create an id attribute for a photo entry
 *
@@ -257,106 +56,10 @@ function createId(url, name) {
     return sha1.digest("hex");
 }
 
-function doNothing(svcId, data, cb) {
-    cb();
-}
 
-
-var dataHandlers = {};
-dataHandlers["timeline/twitter"] = processTwitter;
-dataHandlers["tweets/twitter"] = processTwitter;
-dataHandlers["checkin/foursquare"] = processFoursquare;
-dataHandlers["photo/twitpic"] = processTwitPic;
-dataHandlers["photo/facebook"] = processFacebook;
-dataHandlers["photo/flickr"] = processFlickr;
-dataHandlers["photo/instagram"] = processInstagram;
-dataHandlers["feed/instagram"] = doNothing;
-dataHandlers["post/tumblr"] = processTumblr;
-
-exports.init = function(mongoCollection, mongo, l, config) {
-    collection = mongoCollection;
-    db = mongo.dbClient;
-    locker = l;
-    lconfig = config;
-    logger = require("logger");
-}
-
-exports.getTotalCount = function(callback) {
-    collection.count(callback);
-}
-exports.getAll = function(fields, callback) {
-    collection.find({}, fields, callback);
-}
-
-exports.get = function(id, callback) {
-    var or = []
-    try {
-        or.push({_id:new db.bson_serializer.ObjectID(id)});
-    }catch(E){}
-    or.push({id:id});
-    collection.findOne({$or:or}, callback);
-}
-
-exports.addEvent = function(eventBody, callback) {
-    // TODO:  Handle the other actions appropiately
-    if (eventBody.action !== "new") {
-        callback(null, {});
-        return;
-    }
-    // Run the data processing
-    var idr = url.parse(eventBody.idr, true);
-    var svcId = idr.query["id"];
-    var type = idr.pathname.substr(1) + '/' + idr.host
-    var handler = dataHandlers[type];
-    if (!handler) {
-        logger.warn("unhandled "+type);
-        return callback();
-    }
-    handler(svcId, eventBody.data, callback);
-}
-
-exports.addData = function(svcId, type, allData, callback) {
-    if (callback === undefined) {
-        callback = function() {};
-    }
-    var handler = dataHandlers[type];
-    if (!handler) {
-        logger.warn("unhandled "+type);
-        return callback();
-    }
-    async.forEachSeries(allData,function(data,cb) {
-        handler(svcId, data, cb);
-    },callback);
-}
-
-exports.clear = function(callback) {
-    collection.drop(callback);
-}
-
-function cleanName(name) {
-    if(!name || typeof name != 'string')
-        return name;
-    return name.toLowerCase();
-}
-
-exports.getSince = function(objId, cbEach, cbDone) {
-    findWrap({"_id":{"$gt":lmongoutil.ObjectID(objId)}}, {sort:{_id:-1}}, collection, cbEach, cbDone);
-}
-
-exports.getLastObjectID = function(cbDone) {
-    collection.find({}, {fields:{_id:1}, limit:1, sort:{_id:-1}}).nextObject(cbDone);
-}
-
-function findWrap(a,b,c,cbEach,cbDone){
-    var cursor = c.find(a);
-    if (b.sort) cursor.sort(b.sort);
-    if (b.limit) cursor.limit(b.limit);
-    cursor.each(function(err, item) {
-        if (item != null) {
-            cbEach(item);
-        } else {
-            cbDone();
-        }
-    });
-}
-
+exports.getTotalCount = collectionDataStore.getTotalCount;
+exports.getAll = collectionDataStore.getAll;
+exports.get = collectionDataStore.get;
+exports.clear = collectionDataStore.clear;
+exports.getSince = collectionDataStore.getSince;
+exports.getLastObjectID = collectionDataStore.getLastObjectID;

--- a/Collections/Photos/dataStore.js
+++ b/Collections/Photos/dataStore.js
@@ -57,9 +57,10 @@ function createId(url, name) {
 }
 
 
-exports.getTotalCount = collectionDataStore.getTotalCount;
-exports.getAll = collectionDataStore.getAll;
-exports.get = collectionDataStore.get;
+exports.state = collectionDataStore.state;
 exports.clear = collectionDataStore.clear;
-exports.getSince = collectionDataStore.getSince;
+exports.get = collectionDataStore.get;
+exports.getAll = collectionDataStore.getAll;
 exports.getLastObjectID = collectionDataStore.getLastObjectID;
+exports.getTotalCount = collectionDataStore.getTotalCount;
+exports.getSince = collectionDataStore.getSince;

--- a/Collections/Photos/photos.js
+++ b/Collections/Photos/photos.js
@@ -7,103 +7,17 @@
 *
 */
 
-// merge contacts from connectors
-
 var locker = require('locker.js');
 var logger;
 
-var fs = require('fs');
 var sync = require('./sync');
 var dataStore = require("./dataStore");
 var dataIn = require("./dataIn");
 
-var lockerInfo;
 var express = require('express');
 var connect = require('connect');
 var app = express.createServer(connect.bodyParser());
-var request = require('request');
 
-app.get('/state', function(req, res) {
-    dataStore.getTotalCount(function(err, countInfo) {
-        if(err) return res.send(err, 500);
-        dataStore.getLastObjectID(function(err, lastObject) {
-            if(err) return res.send(err, 500);
-            var objId = "000000000000000000000000";
-            if (lastObject) objId = lastObject._id.toHexString();
-            var updated = Date.now();
-            try {
-                var js = JSON.parse(fs.readFileSync('state.json'));
-                if(js && js.updated) updated = js.updated;
-            } catch(E) {}
-            res.send({ready:1, count:countInfo, updated:updated, lastId:objId});
-        });
-    });
-});
-
-
-app.get('/', function(req, res) {
-    var fields = {};
-    if (req.query.fields) {
-        try {
-            fields = JSON.parse(req.query.fields);
-        } catch(E) {}
-    }
-    dataStore.getAll(fields, function(err, cursor) {
-        if(!req.query["all"]) cursor.limit(20); // default 20 unless all is set
-        if(req.query["limit"]) cursor.limit(parseInt(req.query["limit"]));
-        if(req.query["offset"]) cursor.skip(parseInt(req.query["offset"]));
-        if(req.query['stream'] == "true")
-        {
-            res.writeHead(200, {'content-type' : 'application/jsonstream'});
-            cursor.each(function(err, object){
-                if (err) logger.error(err); // only useful here for logging really
-                if (!object) return res.end();
-                res.write(JSON.stringify(object)+'\n');
-            });
-        }else{
-            cursor.toArray(function(err, items) {
-                res.send(items);
-            });
-        }
-    });
-});
-
-app.get("/since", function(req, res) {
-    if (!req.query.id) {
-        return res.send([]);
-    }
-
-    var results = [];
-    dataStore.getSince(req.query.id, function(item) {
-        results.push(item);
-    }, function() {
-        res.send(results);
-    });
-});
-
-app.get("/image/:photoId", function(req, res) {
-    getImageHelper(req.params.photoId, "url", req.query.proxy, res);
-});
-
-app.get("/thumbnail/:photoId", function(req, res) {
-    getImageHelper(req.params.photoId, "thumbnail", req.query.proxy, res);
-});
-
-function getImageHelper(id, field, proxy, res) {
-    if (!id) {
-        res.writeHead(500);
-        res.end("No photo id supplied");
-        return;
-    }
-    dataStore.get(id, function(error, data) {
-        if (error || !data || !data[field]) return res.send(error||"no data", 500);
-        res.header("Access-Control-Allow-Origin", "*");
-        res.header("Access-Control-Allow-Headers", "X-Requested-With");
-        if(proxy) return request.get({url:data[field]}).pipe(res);
-        res.writeHead(302, {"location":data[field]});
-        return res.end("");
-    });
-};
 
 app.get('/update', function(req, res) {
     sync.gatherPhotos(function(){
@@ -114,36 +28,24 @@ app.get('/update', function(req, res) {
 app.post('/events', function(req, res) {
     if (!req.body.idr || !req.body.data) {
         logger.warn("Invalid event.");
-        res.writeHead(500);
-        res.end("Invalid Event");
-        return;
+        return res.send("Invalid Event", 500);
     }
 
     dataIn.addEvent(req.body, function(err, eventObj) {
         if (err) {
             logger.error("Error processing: " + err);
-            res.writeHead(500);
-            res.end(err);
-            return;
+            return res.send(err, 500);
         }
 
-        res.writeHead(200);
-        res.end("Event Handled");
+        res.send("Event Handled");
     });
-});
-
-app.get('/id/:id', function(req, res, next) {
-    dataStore.get(req.param('id'), function(err, doc) {
-        if(err) return res.send(err, 500);
-        res.send(doc);
-    })
 });
 
 
 // Process the startup JSON object
 process.stdin.resume();
 process.stdin.on('data', function(data) {
-    lockerInfo = JSON.parse(data);
+    var lockerInfo = JSON.parse(data);
     locker.initClient(lockerInfo);
     if (!lockerInfo || !lockerInfo['workingDirectory']) {
         process.stderr.write('Was not passed valid startup information.'+data+'\n');

--- a/Collections/Photos/photos.js
+++ b/Collections/Photos/photos.js
@@ -15,10 +15,11 @@ var logger;
 var fs = require('fs');
 var sync = require('./sync');
 var dataStore = require("./dataStore");
+var dataIn = require("./dataIn");
 
 var lockerInfo;
-var express = require('express'),
-    connect = require('connect');
+var express = require('express');
+var connect = require('connect');
 var app = express.createServer(connect.bodyParser());
 var request = require('request');
 
@@ -118,7 +119,7 @@ app.post('/events', function(req, res) {
         return;
     }
 
-    dataStore.addEvent(req.body, function(err, eventObj) {
+    dataIn.addEvent(req.body, function(err, eventObj) {
         if (err) {
             logger.error("Error processing: " + err);
             res.writeHead(500);
@@ -154,7 +155,7 @@ process.stdin.on('data', function(data) {
     lconfig.load('../../Config/config.json');
     logger = require("logger.js");
     locker.connectToMongo(function(mongo) {
-        sync.init(lockerInfo.lockerUrl, mongo.collections.photo, mongo, locker, lconfig);
+        sync.init(lockerInfo.lockerUrl, mongo, locker, lconfig);
         app.listen(0, function() {
             var returnedInfo = {port: app.address().port};
             process.stdout.write(JSON.stringify(returnedInfo));

--- a/Collections/Photos/sync.js
+++ b/Collections/Photos/sync.js
@@ -15,11 +15,11 @@ var lockerUrl;
 var EventEmitter = require('events').EventEmitter;
 var logger;
 
-exports.init = function(theLockerUrl, mongoCollection, mongo, locker, config) {
+exports.init = function(theLockerUrl, mongo, locker, config) {
     lockerUrl = theLockerUrl;
     lconfig = config;
     logger = require("logger.js");
-    dataStore.init(mongoCollection, mongo, locker, lconfig);
+    dataStore.init(mongo, locker);
     exports.eventEmitter = new EventEmitter();
 }
 

--- a/Collections/Photos/sync.js
+++ b/Collections/Photos/sync.js
@@ -11,6 +11,7 @@ var request = require('request');
 var locker = require('locker.js');
 var lconfig;
 var dataStore = require('./dataStore');
+var dataIn = require('./dataIn');
 var lockerUrl;
 var EventEmitter = require('events').EventEmitter;
 var logger;
@@ -89,7 +90,7 @@ function gatherFromUrl(svcId, url, type) {
         try {
             var arr = JSON.parse(body);
             if (!arr) throw("No data");
-            dataStore.addData(svcId, type, arr);
+            dataIn.addData(svcId, type, arr);
         } catch (E) {
             logger.error("Error processing photos from " + svcId + url + ": " + E);
         }

--- a/Collections/Photos/sync.js
+++ b/Collections/Photos/sync.js
@@ -22,6 +22,7 @@ exports.init = function(theLockerUrl, mongo, locker, config) {
     logger = require("logger.js");
     dataStore.init(mongo, locker);
     exports.eventEmitter = new EventEmitter();
+    dataIn.init();
 }
 
 var photoGatherers = {

--- a/Collections/Places/api.js
+++ b/Collections/Places/api.js
@@ -1,0 +1,108 @@
+var fs = require('fs');
+var path = require('path');
+var locker = require('locker');
+var logger = require('logger');
+var request = require('request');
+var url = require('url');
+
+module.exports = function(app, lockerInfo) {
+
+  var dataStore = require(path.join(lockerInfo.sourceDirectory, 'dataStore.js'));
+  locker.initClient(lockerInfo);
+
+  locker.connectToMongo(function(mongo) {
+    // initialize all our libs
+    dataStore.init(mongo, locker, lockerInfo);
+    // TODO: this is a race condition. The routes will be added before the dataStore is initialized
+    // callback();
+  });
+
+  app.get('/state', function(req, res) {
+    dataStore.state(function(err, state) {
+      if(err) return res.send(err, 500)
+      res.send(state);
+    });
+  });
+
+  app.get('/since', function(req, res) {
+    if (!req.query.id) {
+      return res.send([]);
+    }
+
+    var results = [];
+    dataStore.getSince(req.query.id, function(item) {
+      results.push(item);
+    }, function() {
+      res.send(results);
+    });
+  });
+
+
+  app.get('', function index(req, res) {
+    var fields = {};
+    if (req.query.fields) {
+      try {
+        fields = JSON.parse(req.query.fields);
+      } catch(E) {}
+    }
+    dataStore.getAll(fields, function(err, cursor) {
+      if(!req.query.all) cursor.limit(20); // default 20 unless all is set
+      if(req.query.limit) cursor.limit(parseInt(req.query.limit));
+      if(req.query.offset) cursor.skip(parseInt(req.query.offset));
+      if(req.query.sort) {
+        var sorter = {}
+        if(req.query.order) {
+          sorter[req.query.sort] = +req.query.order;
+        } else {
+          sorter[req.query.sort] = 1;
+        }
+        cursor.sort(sorter);
+      }
+      if(req.query.stream == 'true')
+      {
+        res.writeHead(200, {'content-type' : 'application/jsonstream'});
+        cursor.each(function(err, object){
+          if (err) logger.error(err); // only useful here for logging really
+          if (!object) return res.end();
+          res.write(JSON.stringify(object)+'\n');
+        });
+      }else{
+        cursor.toArray(function(err, items) {
+          res.send(items);
+        });
+      }
+    });
+  });
+
+  app.get('/id/:id', function(req, res, next) {
+    dataStore.get(req.param('id'), function(err, doc) {
+      res.send(doc);
+    })
+  });
+
+  // an experimental direct api to get places specifically from one id on one network, and with ?full=true flag to pull in origin via data!
+  var cache = {};
+  app.get('/from/:network/:from', function(req, res) {
+    if (!req.param('from')) return res.send([]);
+
+    var results = [];
+    dataStore.getFrom(req.param('network'), req.param('from'), function(item) {
+      results.push(item);
+    }, function() {
+      if(!req.query.full) return res.send(results);
+      async.forEachSeries(results, function(place, cb){
+        if(cache[place.via]) place.via = cache[place.via];
+        request.get({uri:locker.lockerBase+place.via, json:true}, function(err, res, js){
+          if(js) {
+            cache[place.via] = js;
+            place.via = js;
+          }
+          cb();
+        });
+      }, function(){
+        res.send(results);
+      })
+    });
+  });
+
+};

--- a/Collections/Places/dataIn.js
+++ b/Collections/Places/dataIn.js
@@ -1,0 +1,228 @@
+var dataStore = require('./dataStore');
+var url = require('url');
+
+var dataHandlers = {};
+dataHandlers["checkin/foursquare"] = processFoursquare;
+dataHandlers["recents/foursquare"] = processFoursquare;
+dataHandlers["tweets/twitter"] = processTwitter;
+dataHandlers["timeline/twitter"] = processTwitter;
+dataHandlers["location/glatitude"] = processGLatitude;
+dataHandlers["photo/instagram"] = processInstagram;
+dataHandlers["feed/instagram"] = processInstagram;
+
+
+function processFoursquare(svcId, type, data, cb) {
+    // Gotta have lat/lng/at at minimum
+    var loc = (data.venue) ? data.venue.location : data.location; // venueless happens
+    if (!loc || !loc.lat || !loc.lng || !data.createdAt) {
+        cb("The 4sq data did not have lat/lng or at: "+JSON.stringify(data));
+        return;
+    }
+
+    var me = false;
+    if (type === 'checkin/foursquare') {
+        me = true;
+    }
+
+    var placeInfo = {
+            me:me,
+            network:"foursquare",
+            path: false,
+            title: (data.venue) ? data.venue.name : data.location.name,
+            from: '',
+            lat: loc.lat,
+            lng: loc.lng,
+            at: data.createdAt * 1000,
+            via: '/Me/' + svcId + '/' + type.split('/')[0] + '/id/' + data._id
+        };
+
+    // "checkins" are from yourself, kinda problematic to deal with here?
+    if (data.user) {
+        placeInfo.fromID = data.user.id;
+        placeInfo.from = '';
+        if (data !== null && data.hasOwnProperty('user') && data.user.hasOwnProperty('firstName')) {
+            placeInfo.from += data.user.firstName.replace(/^\w/, function($0) { return $0.toUpperCase(); });
+        }
+        if (data !== null && data.hasOwnProperty('user') && data.user.hasOwnProperty('lastName')) {
+            placeInfo.from += ' ' + data.user.lastName.replace(/^\w/, function($0) { return $0.toUpperCase(); });
+        }
+    } else if (!data.user && me === true) {
+        placeInfo.from = 'Me';
+    }
+    dataStore.saveCommonPlace(placeInfo, cb);
+}
+
+function processTwitter(svcId, type, data, cb) {
+    // Gotta have geo/at at minimum
+    if (!data.created_at) {
+        cb("The Twitter data did not have created_at");
+        return;
+    }
+
+    var title = '';
+    if (data !== null && data.hasOwnProperty('place') && data.place !== null && data.place.hasOwnProperty('full_name')) {
+        title = data.place.full_name.replace(/\n/g,'').replace(/\s+/g, ' ').replace(/^\w/, function($0) { return $0.toUpperCase(); });
+    }
+
+    var ll = firstLL(data.geo) || firstLL(data.coordinates, true) ||
+        (data.place !== null && data.place.hasOwnProperty('bounding_box') && computedLL(data.place.bounding_box.coordinates[0]));
+    if (!ll) {
+        // quietly return, as lots of tweets aren't geotagged, so let's just bail
+        return cb();
+    }
+
+    var me = false;
+    if (type === 'tweets/twitter') {
+        me = true;
+    }
+
+    var placeInfo = {
+            me:me,
+            lat: ll[0],
+            lng: ll[1],
+            path: false,
+            title: title,
+            network:"twitter",
+            text: data.text,
+            from: (data.user)?data.user.name.replace(/^\w/, function($0) { return $0.toUpperCase(); }):"",
+            fromID: (data.user)?data.user.id:"",
+            at: new Date(data.created_at).getTime(),
+            via: '/Me/' + svcId + '/' + type.split('/')[0] + '/id/'+data._id
+        };
+    dataStore.saveCommonPlace(placeInfo, cb);
+}
+
+function processInstagram(svcId, type, data, cb) {
+    // Gotta have location/at at minimum
+    if (!data || !data.created_time || !data.location || !data.location.latitude || !data.location.longitude) {
+        cb();
+        return;
+    }
+
+    var me = false;
+    if (type === 'photo/instagram') {
+        me = true; // I think this is probably getting overwritten, fix the right way when we do profiles uniformly
+    }
+
+    var placeInfo = {
+            me:me,
+            lat: data.location.latitude,
+            lng: data.location.longitude,
+            path: false,
+            title: (data.caption && data.caption.text) ? data.caption.text : '',
+            network:"instagram",
+            from: (data.user)?data.user.full_name:"",
+            fromID: (data.user)?data.user.id:"",
+            at: data.created_time * 1000,
+            via: '/Me/' + svcId + '/' + type.split('/')[0] + '/id/'+data._id
+        };
+    dataStore.saveCommonPlace(placeInfo, cb);
+}
+
+function processGLatitude(svcId, type, data, cb) {
+    // Gotta have lat/lng/at at minimum
+    if (!data.latitude || !data.longitude) {
+        cb("The Latitude data did not have latitude or longitude");
+        return;
+    }
+
+    var timestamp = parseInt(data.timestampMs, 10);
+    if (isNaN(timestamp)) {
+        cb("The Latitude data did not have a valid timestamp");
+        return;
+    }
+
+    var me = false;
+    if (type === 'location/glatitude') {
+        me = true;
+    }
+
+    var placeInfo = {
+            me:me,
+            network:"glatitude",
+            path: true,
+            title: '',
+            from: 'Me',
+            lat: data.latitude,
+            lng: data.longitude,
+            at: timestamp,
+            via: '/Me/' + svcId + '/' + type.split('/')[0] + '/id/'+data._id
+        };
+    dataStore.saveCommonPlace(placeInfo, cb);
+}
+
+
+exports.addEvent = function(eventBody, callback) {
+    if (eventBody.action !== "new") {
+        callback(null, {});
+        return;
+    }
+    // Run the data processing
+    var idr = url.parse(eventBody.idr, true);
+    var svcId = idr.query["id"];
+    var type = idr.pathname.substr(1) + '/' + idr.host
+    var handler = dataHandlers[type];
+    if (!handler) {
+        logger.warn("unhandled "+type);
+        return callback();
+    }
+    handler(svcId, type, eventBody.data, callback);
+};
+
+exports.addData = function(svcId, type, allData, callback) {
+    if (callback === undefined) {
+        callback = function() {};
+    }
+    var handler = dataHandlers[type];
+    if (!handler) {
+        logger.warn("unhandled "+type);
+        return callback();
+    }
+    // if called with just one item, streaming
+    if(!Array.isArray(allData))
+    {
+        handler(svcId, type, allData, function(e){
+            if(e) logger.error("error processing: "+e);
+            callback();
+        });
+        return;
+    }
+    async.forEachSeries(allData, function(data, cb) {
+        handler(svcId, type, data, function(e){
+            if(e) logger.error("error processing: "+e);
+            cb();
+        });
+    }, callback);
+};
+
+
+// hack to inspect until we find any [123,456]
+function firstLL(o, reversed) {
+    if (Array.isArray(o) && o.length == 2 &&
+        typeof o[0] == 'number' && typeof o[1] == 'number') {
+        return (reversed) ? [o[1],o[0]] : o; // reverse them optionally
+    }
+    if (typeof o != 'object') {
+        return null;
+    }
+    for (var i in o) {
+        var ret = firstLL(o[i], reversed);
+        if(ret) return ret;
+    }
+    return null;
+}
+
+// Find center of bounding boxed LL array
+function computedLL(box) {
+    var allLat = 0;
+    var allLng = 0;
+
+    for (var i=0; i<box.length; ++i) {
+        allLat += box[i][1];
+        allLng += box[i][0];
+    }
+    var lat = +(allLat / 4).toFixed(5);
+    var lng = +(allLng / 4).toFixed(5);
+
+    return [lat, lng];
+}

--- a/Collections/Places/dataStore.js
+++ b/Collections/Places/dataStore.js
@@ -17,161 +17,32 @@ var crypto = require("crypto");
 var async = require("async");
 var url = require("url");
 var fs = require('fs');
-var lmongoutil = require("lmongoutil");
 
-function processFoursquare(svcId, type, data, cb) {
-    // Gotta have lat/lng/at at minimum
-    var loc = (data.venue) ? data.venue.location : data.location; // venueless happens
-    if (!loc || !loc.lat || !loc.lng || !data.createdAt) {
-        cb("The 4sq data did not have lat/lng or at: "+JSON.stringify(data));
-        return;
-    }
+var collectionDataStore = require('collectionDataStore')();
 
-    var me = false;
-    if (type === 'checkin/foursquare') {
-        me = true;
-    }
+exports.init = function(mongo, l, config) {
+    var mongoCollection = mongo.collections.place;
+    collectionDataStore.init(mongo, 'place', l);
 
-    var placeInfo = {
-            me:me,
-            network:"foursquare",
-            path: false,
-            title: (data.venue) ? data.venue.name : data.location.name,
-            from: '',
-            lat: loc.lat,
-            lng: loc.lng,
-            at: data.createdAt * 1000,
-            via: '/Me/' + svcId + '/' + type.split('/')[0] + '/id/' + data._id
-        };
+    collection = mongoCollection;
+    collection.ensureIndex({"id":1},{unique:true},function() {});
+    db = mongo.dbClient;
+    locker = l;
+    lconfig = config;
+    logger = require("logger");
+};
 
-    // "checkins" are from yourself, kinda problematic to deal with here?
-    if (data.user) {
-        placeInfo.fromID = data.user.id;
-        placeInfo.from = '';
-        if (data !== null && data.hasOwnProperty('user') && data.user.hasOwnProperty('firstName')) {
-            placeInfo.from += data.user.firstName.replace(/^\w/, function($0) { return $0.toUpperCase(); });
-        }
-        if (data !== null && data.hasOwnProperty('user') && data.user.hasOwnProperty('lastName')) {
-            placeInfo.from += ' ' + data.user.lastName.replace(/^\w/, function($0) { return $0.toUpperCase(); });
-        }
-    } else if (!data.user && me === true) {
-        placeInfo.from = 'Me';
-    }
-    saveCommonPlace(placeInfo, cb);
-}
+// inherit from collectionDataStore
+exports.state = collectionDataStore.state;
+exports.clear = collectionDataStore.clear;
+exports.get = collectionDataStore.get;
+exports.getOne = collectionDataStore.getOne;
+exports.getAll = collectionDataStore.getAll;
+exports.getLastObjectID = collectionDataStore.getLastObjectID;
+exports.getTotalCount = collectionDataStore.getTotalCount;
+exports.getSince = collectionDataStore.getSince;
 
-function processTwitter(svcId, type, data, cb) {
-    // Gotta have geo/at at minimum
-    if (!data.created_at) {
-        cb("The Twitter data did not have created_at");
-        return;
-    }
-
-    var title = '';
-    if (data !== null && data.hasOwnProperty('place') && data.place !== null && data.place.hasOwnProperty('full_name')) {
-        title = data.place.full_name.replace(/\n/g,'').replace(/\s+/g, ' ').replace(/^\w/, function($0) { return $0.toUpperCase(); });
-    }
-
-    var ll = firstLL(data.geo) || firstLL(data.coordinates, true) ||
-        (data.place !== null && data.place.hasOwnProperty('bounding_box') && computedLL(data.place.bounding_box.coordinates[0]));
-    if (!ll) {
-        // quietly return, as lots of tweets aren't geotagged, so let's just bail
-        return cb();
-    }
-
-    var me = false;
-    if (type === 'tweets/twitter') {
-        me = true;
-    }
-
-    var placeInfo = {
-            me:me,
-            lat: ll[0],
-            lng: ll[1],
-            path: false,
-            title: title,
-            network:"twitter",
-            text: data.text,
-            from: (data.user)?data.user.name.replace(/^\w/, function($0) { return $0.toUpperCase(); }):"",
-            fromID: (data.user)?data.user.id:"",
-            at: new Date(data.created_at).getTime(),
-            via: '/Me/' + svcId + '/' + type.split('/')[0] + '/id/'+data._id
-        };
-    saveCommonPlace(placeInfo, cb);
-}
-
-function processInstagram(svcId, type, data, cb) {
-    // Gotta have location/at at minimum
-    if (!data || !data.created_time || !data.location || !data.location.latitude || !data.location.longitude) {
-        cb();
-        return;
-    }
-
-    var me = false;
-    if (type === 'photo/instagram') {
-        me = true; // I think this is probably getting overwritten, fix the right way when we do profiles uniformly
-    }
-
-    var placeInfo = {
-            me:me,
-            lat: data.location.latitude,
-            lng: data.location.longitude,
-            path: false,
-            title: (data.caption && data.caption.text) ? data.caption.text : '',
-            network:"instagram",
-            from: (data.user)?data.user.full_name:"",
-            fromID: (data.user)?data.user.id:"",
-            at: data.created_time * 1000,
-            via: '/Me/' + svcId + '/' + type.split('/')[0] + '/id/'+data._id
-        };
-    saveCommonPlace(placeInfo, cb);
-}
-
-function processGLatitude(svcId, type, data, cb) {
-    // Gotta have lat/lng/at at minimum
-    if (!data.latitude || !data.longitude) {
-        cb("The Latitude data did not have latitude or longitude");
-        return;
-    }
-
-    var timestamp = parseInt(data.timestampMs, 10);
-    if (isNaN(timestamp)) {
-        cb("The Latitude data did not have a valid timestamp");
-        return;
-    }
-
-    var me = false;
-    if (type === 'location/glatitude') {
-        me = true;
-    }
-
-    var placeInfo = {
-            me:me,
-            network:"glatitude",
-            path: true,
-            title: '',
-            from: 'Me',
-            lat: data.latitude,
-            lng: data.longitude,
-            at: timestamp,
-            via: '/Me/' + svcId + '/' + type.split('/')[0] + '/id/'+data._id
-        };
-    saveCommonPlace(placeInfo, cb);
-}
-
-var writeTimer = false;
-function updateState() {
-    if (writeTimer) {
-        clearTimeout(writeTimer);
-    }
-    writeTimer = setTimeout(function() {
-        try {
-            lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:Date.now()}));
-        } catch (E) {}
-    }, 5000);
-}
-
-function saveCommonPlace(placeInfo, cb) {
+exports.saveCommonPlace = function(placeInfo, cb) {
     placeInfo.lat = +(placeInfo.lat.toFixed(5));
     placeInfo.lng = +(placeInfo.lng.toFixed(5));
     var hash = createId(placeInfo.lat+':'+placeInfo.lng+':'+placeInfo.at);
@@ -181,190 +52,35 @@ function saveCommonPlace(placeInfo, cb) {
         if (err) {
             return cb(err);
         }
-        updateState();
+        collectionDataStore.updateState();
         locker.ievent(lutil.idrNew("place","places",doc.id), doc);
         return cb(undefined, doc);
     });
 }
 
-var dataHandlers = {};
-dataHandlers["checkin/foursquare"] = processFoursquare;
-dataHandlers["recents/foursquare"] = processFoursquare;
-dataHandlers["tweets/twitter"] = processTwitter;
-dataHandlers["timeline/twitter"] = processTwitter;
-dataHandlers["location/glatitude"] = processGLatitude;
-dataHandlers["photo/instagram"] = processInstagram;
-dataHandlers["feed/instagram"] = processInstagram;
-
-exports.init = function(mongoCollection, mongo, l, config) {
-    collection = mongoCollection;
-    collection.ensureIndex({"id":1},{unique:true},function() {});
-    db = mongo.dbClient;
-    locker = l;
-    lconfig = config;
-    logger = require("logger");
-};
-
-exports.updatePlace = function(place, cb)
-{
+exports.updatePlace = function(place, cb) {
     if(!place || !place.id) return cb("missing valid place");
     var query = [{id:place.id}];
     delete place._id;
     collection.findAndModify({$or:query}, [['_id','asc']], {$set:place}, {safe:true, upsert:true, new: true}, function(err, doc) {
         if (err) return cb(err);
-        updateState();
+        collectionDataStore.updateState();
         locker.ievent(lutil.idrNew("place","places",doc.id), doc, "update");
         return cb(undefined, doc);
     });
 };
 
-exports.getTotalCount = function(callback) {
-    collection.count(callback);
-};
-
-exports.getAll = function(fields, callback) {
-    collection.find({}, fields, callback);
-};
-
-exports.get = function(id, callback) {
-    var or = []
-    try {
-        or.push({_id:new db.bson_serializer.ObjectID(id)});
-    }catch(E){}
-    or.push({id:id});
-    collection.findOne({$or:or}, callback);
-};
-
-exports.getOne = function(id, callback) {
-    collection.find({"id":id}, function(error, cursor) {
-        if (error) {
-            callback(error, null);
-        } else {
-            cursor.nextObject(function(err, doc) {
-                if (err)
-                    callback(err);
-                else
-                    callback(err, doc);
-            });
-        }
-    });
-};
-
-exports.addEvent = function(eventBody, callback) {
-    if (eventBody.action !== "new") {
-        callback(null, {});
-        return;
-    }
-    // Run the data processing
-    var idr = url.parse(eventBody.idr, true);
-    var svcId = idr.query["id"];
-    var type = idr.pathname.substr(1) + '/' + idr.host
-    var handler = dataHandlers[type];
-    if (!handler) {
-        logger.warn("unhandled "+type);
-        return callback();
-    }
-    handler(svcId, type, eventBody.data, callback);
-};
-
-exports.addData = function(svcId, type, allData, callback) {
-    if (callback === undefined) {
-        callback = function() {};
-    }
-    var handler = dataHandlers[type];
-    if (!handler) {
-        logger.warn("unhandled "+type);
-        return callback();
-    }
-    // if called with just one item, streaming
-    if(!Array.isArray(allData))
-    {
-        handler(svcId, type, allData, function(e){
-            if(e) logger.error("error processing: "+e);
-            callback();
-        });
-        return;
-    }
-    async.forEachSeries(allData, function(data, cb) {
-        handler(svcId, type, data, function(e){
-            if(e) logger.error("error processing: "+e);
-            cb();
-        });
-    }, callback);
-};
-
-exports.clear = function(callback) {
-    collection.drop(callback);
-};
-
-exports.getSince = function(objId, cbEach, cbDone) {
-    findWrap({"_id":{"$gt":lmongoutil.ObjectID(objId)}}, {sort:{_id:-1}}, collection, cbEach, cbDone);
-};
 
 exports.getNetwork = function(network, cbEach, cbDone) {
-    findWrap({"network":network}, {}, collection, cbEach, cbDone);
+    collectionDataStore.findWrap({"network":network}, {}, collection, cbEach, cbDone);
 };
 
 exports.getFrom = function(network, from, cbEach, cbDone) {
-    findWrap({"network":network, "fromID":from}, {}, collection, cbEach, cbDone);
+    collectionDataStore.findWrap({"network":network, "fromID":from}, {}, collection, cbEach, cbDone);
 };
-
-exports.getLastObjectID = function(cbDone) {
-    collection.find({}, {fields:{_id:1}, limit:1, sort:{_id:-1}}).nextObject(cbDone);
-};
-
-function cleanName(name) {
-    if(!name || typeof name !== 'string')
-        return name;
-    return name.toLowerCase();
-}
 
 function createId(hash) {
     var sha1 = crypto.createHash("sha1");
     sha1.update(hash);
     return sha1.digest("hex");
-}
-
-function findWrap(a,b,c,cbEach,cbDone) {
-    var cursor = c.find(a);
-    if (b.sort) cursor.sort(b.sort);
-    if (b.limit) cursor.limit(b.limit);
-    cursor.each(function(err, item) {
-        if (item !== null) {
-            cbEach(item);
-        } else {
-            cbDone();
-        }
-    });
-}
-
-// hack to inspect until we find any [123,456]
-function firstLL(o, reversed) {
-    if (Array.isArray(o) && o.length == 2 &&
-        typeof o[0] == 'number' && typeof o[1] == 'number') {
-        return (reversed) ? [o[1],o[0]] : o; // reverse them optionally
-    }
-    if (typeof o != 'object') {
-        return null;
-    }
-    for (var i in o) {
-        var ret = firstLL(o[i], reversed);
-        if(ret) return ret;
-    }
-    return null;
-}
-
-// Find center of bounding boxed LL array
-function computedLL(box) {
-    var allLat = 0;
-    var allLng = 0;
-
-    for (var i=0; i<box.length; ++i) {
-        allLat += box[i][1];
-        allLng += box[i][0];
-    }
-    var lat = +(allLat / 4).toFixed(5);
-    var lng = +(allLng / 4).toFixed(5);
-
-    return [lat, lng];
 }

--- a/Collections/Places/dataStore.js
+++ b/Collections/Places/dataStore.js
@@ -9,27 +9,25 @@
 var collection;
 var db;
 var locker;
-var lconfig;
 var lutil = require('lutil');
-var logger;
 var request = require("request");
 var crypto = require("crypto");
 var async = require("async");
 var url = require("url");
 var fs = require('fs');
 
-var collectionDataStore = require('collectionDataStore')();
+var CollectionDataStore = require('collectionDataStore');
+var collectionDataStore = new CollectionDataStore();
 
-exports.init = function(mongo, l, config) {
+exports.init = function(mongo, _locker) {
+    locker = _locker;
     var mongoCollection = mongo.collections.place;
-    collectionDataStore.init(mongo, 'place', l);
+    collectionDataStore.init(mongo, 'place', locker);
 
     collection = mongoCollection;
     collection.ensureIndex({"id":1},{unique:true},function() {});
     db = mongo.dbClient;
-    locker = l;
-    lconfig = config;
-    logger = require("logger");
+
 };
 
 // inherit from collectionDataStore
@@ -72,11 +70,11 @@ exports.updatePlace = function(place, cb) {
 
 
 exports.getNetwork = function(network, cbEach, cbDone) {
-    collectionDataStore.findWrap({"network":network}, {}, collection, cbEach, cbDone);
+    collectionDataStore.findWrap({"network":network}, {}, cbEach, cbDone);
 };
 
 exports.getFrom = function(network, from, cbEach, cbDone) {
-    collectionDataStore.findWrap({"network":network, "fromID":from}, {}, collection, cbEach, cbDone);
+    collectionDataStore.findWrap({"network":network, "fromID":from}, {}, cbEach, cbDone);
 };
 
 function createId(hash) {

--- a/Collections/Places/dataStore.js
+++ b/Collections/Places/dataStore.js
@@ -21,10 +21,9 @@ var collectionDataStore = new CollectionDataStore();
 
 exports.init = function(mongo, _locker) {
     locker = _locker;
-    var mongoCollection = mongo.collections.place;
+    collection = mongo.collections.place;
     collectionDataStore.init(mongo, 'place', locker);
 
-    collection = mongoCollection;
     collection.ensureIndex({"id":1},{unique:true},function() {});
     db = mongo.dbClient;
 

--- a/Collections/Places/places.js
+++ b/Collections/Places/places.js
@@ -13,7 +13,7 @@ var locker = require('locker.js');
 
 var fs = require('fs');
 var sync = require('./sync');
-var dataStore = require("./dataStore");
+var dataIn = require('./dataIn');
 var logger;
 
 var lockerInfo;
@@ -22,73 +22,6 @@ var express = require('express'),
 var app = express.createServer(connect.bodyParser());
 var request = require('request');
 var async = require('async');
-
-app.get('/state', function(req, res) {
-    dataStore.getTotalCount(function(err, countInfo) {
-        if(err) return res.send(err, 500);
-        dataStore.getLastObjectID(function(err, lastObject) {
-            if(err) return res.send(err, 500);
-            var objId = "000000000000000000000000";
-            if (lastObject) objId = lastObject._id.toHexString();
-            var updated = Date.now();
-            try {
-                var js = JSON.parse(fs.readFileSync('state.json'));
-                if(js && js.updated) updated = js.updated;
-            } catch(E) {}
-            res.send({ready:1, count:countInfo, updated:updated, lastId:objId});
-        });
-    });
-});
-
-
-app.get('/', function(req, res) {
-    var fields = {};
-    if (req.query.fields) {
-        try {
-            fields = JSON.parse(req.query.fields);
-        } catch(E) {}
-    }
-    dataStore.getAll(fields, function(err, cursor) {
-        if(!req.query["all"]) cursor.limit(20); // default 20 unless all is set
-        if(req.query["limit"]) cursor.limit(parseInt(req.query["limit"]));
-        if(req.query["offset"]) cursor.skip(parseInt(req.query["offset"]));
-        if(req.query["sort"]) {
-            var sorter = {}
-            if(req.query["order"]) {
-                sorter[req.query["sort"]] = +req.query["order"];
-            } else {
-                sorter[req.query["sort"]] = 1;
-            }
-            cursor.sort(sorter);
-        }
-        if(req.query['stream'] == "true")
-        {
-            res.writeHead(200, {'content-type' : 'application/jsonstream'});
-            cursor.each(function(err, object){
-                if (err) logger.error(err); // only useful here for logging really
-                if (!object) return res.end();
-                res.write(JSON.stringify(object)+'\n');
-            });
-        }else{
-            cursor.toArray(function(err, items) {
-                res.send(items);
-            });
-        }
-    });
-});
-
-app.get("/since", function(req, res) {
-    if (!req.query.id) {
-        return res.send([]);
-    }
-
-    var results = [];
-    dataStore.getSince(req.query.id, function(item) {
-        results.push(item);
-    }, function() {
-        res.send(results);
-    });
-});
 
 app.get('/update', function(req, res) {
     sync.gatherPlaces(req.query.type, function(){
@@ -104,33 +37,6 @@ app.get('/geo/:network', function(req, res) {
     });
 });
 
-// an experimental direct api to get places specifically from one id on one network, and with ?full=true flag to pull in origin via data!
-var cache = {};
-app.get('/from/:network/:from', function(req, res) {
-    if (!req.param("from")) {
-        return res.send([]);
-    }
-
-    var results = [];
-    dataStore.getFrom(req.param("network"), req.param("from"), function(item) {
-        results.push(item);
-    }, function() {
-        if(!req.query.full) return res.send(results);
-        async.forEachSeries(results, function(place, cb){
-            if(cache[place.via]) place.via = cache[place.via];
-            request.get({uri:locker.lockerBase+place.via, json:true}, function(err, res, js){
-                if(js) {
-                    cache[place.via] = js;
-                    place.via = js;
-                }
-                cb();
-            });
-        }, function(){
-            res.send(results);
-        })
-    });
-});
-
 app.post('/events', function(req, res) {
     if (!req.body.idr || !req.body.data) {
         logger.error("Invalid event.");
@@ -139,7 +45,7 @@ app.post('/events', function(req, res) {
         return;
     }
 
-    dataStore.addEvent(req.body, function(err, eventObj) {
+    dataIn.addEvent(req.body, function(err, eventObj) {
         if (err) {
             logger.error("Error processing: " + err);
             res.writeHead(500);
@@ -152,16 +58,11 @@ app.post('/events', function(req, res) {
     });
 });
 
-app.get('/id/:id', function(req, res, next) {
-    dataStore.get(req.param('id'), function(err, doc) {
-        res.send(doc);
-    })
-});
-
 
 // Process the startup JSON object
 process.stdin.resume();
 process.stdin.on('data', function(data) {
+  console.error('places startup');
     lockerInfo = JSON.parse(data);
     locker.initClient(lockerInfo);
     if (!lockerInfo || !lockerInfo['workingDirectory']) {
@@ -173,7 +74,7 @@ process.stdin.on('data', function(data) {
     lconfig.load('../../Config/config.json');
     logger = require("logger.js");
     locker.connectToMongo(function(mongo) {
-        sync.init(lockerInfo.lockerUrl, mongo.collections.place, mongo, locker, lconfig);
+        sync.init(lockerInfo.lockerUrl, mongo, locker, lconfig);
         app.listen(0, function() {
             var returnedInfo = {port: app.address().port};
             process.stdout.write(JSON.stringify(returnedInfo));

--- a/Collections/Places/places.js
+++ b/Collections/Places/places.js
@@ -17,8 +17,8 @@ var dataIn = require('./dataIn');
 var logger;
 
 var lockerInfo;
-var express = require('express'),
-    connect = require('connect');
+var express = require('express');
+var connect = require('connect');
 var app = express.createServer(connect.bodyParser());
 var request = require('request');
 var async = require('async');
@@ -33,24 +33,20 @@ app.get('/update', function(req, res) {
 app.get('/geo/:network', function(req, res) {
     sync.geoCode(req.param('network'), function(err){
         if(err) logger.error(err);
-        res.send(true);
+        return res.send(true);
     });
 });
 
 app.post('/events', function(req, res) {
     if (!req.body.idr || !req.body.data) {
         logger.error("Invalid event.");
-        res.writeHead(500);
-        res.end("Invalid Event");
-        return;
+        return res.send("Invalid Event", 500);
     }
 
     dataIn.addEvent(req.body, function(err, eventObj) {
         if (err) {
             logger.error("Error processing: " + err);
-            res.writeHead(500);
-            res.end(err);
-            return;
+            return res.send(err, 500);
         }
 
         res.writeHead(200);
@@ -62,10 +58,9 @@ app.post('/events', function(req, res) {
 // Process the startup JSON object
 process.stdin.resume();
 process.stdin.on('data', function(data) {
-  console.error('places startup');
     lockerInfo = JSON.parse(data);
     locker.initClient(lockerInfo);
-    if (!lockerInfo || !lockerInfo['workingDirectory']) {
+    if (!lockerInfo || !lockerInfo.workingDirectory) {
         process.stderr.write('Was not passed valid startup information.'+data+'\n');
         process.exit(1);
     }

--- a/Collections/Places/sync.js
+++ b/Collections/Places/sync.js
@@ -14,15 +14,16 @@ var locker = require('locker.js');
 var lutil = require('lutil');
 var lconfig;
 var dataStore = require('./dataStore');
+var dataIn = require('./dataIn');
 var lockerUrl;
 var EventEmitter = require('events').EventEmitter;
 var logger;
 
-exports.init = function(theLockerUrl, mongoCollection, mongo, locker, config) {
+exports.init = function(theLockerUrl, mongo, locker, config) {
     lockerUrl = theLockerUrl;
     lconfig = config;
     logger = require("logger.js");
-    dataStore.init(mongoCollection, mongo, locker, lconfig);
+    dataStore.init(mongo, locker, lconfig);
     exports.eventEmitter = new EventEmitter();
 };
 
@@ -65,7 +66,7 @@ function gatherFromUrl(svcId, type, callback) {
     var total = 0;
     lutil.streamFromUrl(url, function(js, cb){
         total++;
-        dataStore.addData(svcId, type, js, cb);
+        dataIn.addData(svcId, type, js, cb);
     }, function(){
         logger.info("indexed "+total+" items from "+svcId);
         callback();

--- a/Collections/Places/sync.js
+++ b/Collections/Places/sync.js
@@ -23,7 +23,7 @@ exports.init = function(theLockerUrl, mongo, locker, config) {
     lockerUrl = theLockerUrl;
     lconfig = config;
     logger = require("logger.js");
-    dataStore.init(mongo, locker, lconfig);
+    dataStore.init(mongo, locker);
     exports.eventEmitter = new EventEmitter();
 };
 

--- a/Collections/Search/api.js
+++ b/Collections/Search/api.js
@@ -1,0 +1,60 @@
+var fs = require('fs');
+var path = require('path');
+var locker = require('locker');
+var logger = require('logger');
+var lutil = require('lutil');
+var request = require('request');
+var url = require('url');
+var async = require('async');
+var index = require('./index');
+
+module.exports = function(app, lockerInfo) {
+
+  locker.initClient(lockerInfo);
+
+  index.init(path.join(lockerInfo.workingDirectory, 'index.db'), function(err) {
+    if(err) logger.error(err);
+  });
+
+
+  app.get('/query', function(req, res) {
+    var args = {};
+    args.q = lutil.trim(req.param('q'));
+    if (!args.q || args.q.length == 0) {
+      logger.warn('missing or invalid query');
+      return res.send('missing or invalid query');
+    }
+
+    args.limit = 20;
+    if (req.param('type')) args.type = req.param('type');
+    if (req.param('limit')) args.limit = parseInt(req.param('limit'));
+    if (req.param('snippet') == "true") args.snippet = true;
+    if (req.param('sort') == "true") args.sort = true;
+    if (req.param('type')) args.q = "idr:"+req.param('type')+" "+args.q;
+
+    var all = []; // to keep ordering
+    var ndx = {}; // to keep uniqueness
+    logger.info("performing query "+JSON.stringify(args));
+    index.query(args, function(item){
+      if(ndx[item.idr]) return;
+      ndx[item.idr] = item;
+      all.push(item);
+    }, function(err){
+      if(err) logger.error(err);
+      async.forEachSeries(all, function(item, cb){
+          var idr = url.parse(item.idr);
+          if(!idr || !idr.host || !idr.hash) return cb();
+          var u = lockerInfo.lockerUrl + '/Me/' + idr.host + '/id/' + idr.hash.substr(1) + "?full=true";
+          request.get({uri:u, json:true}, function(err, res, body) {
+              if(err) logger.error("failed to get "+u+" - "+err);
+              if(body) item.data = body;
+              cb();
+          });
+      }, function(err){
+          if(err) logger.error(err);
+          res.send(all);
+      });
+    });
+  });
+
+}

--- a/Common/node/collectionDataStore.js
+++ b/Common/node/collectionDataStore.js
@@ -10,14 +10,13 @@ var fs = require('fs');
 var lutil = require('lutil');
 
 module.exports = function() {
-  var collection, db, logger;
+  var collection, db;
   var client = {};
 
   client.init = function(mongo, collectionName, locker) {
     collection = mongo.collections[collectionName];
     collection.ensureIndex({"id":1},{unique:true},function() {});
     db = mongo.dbClient;
-    logger = require("logger");
   }
 
   client.state = function(callback) {
@@ -36,13 +35,14 @@ module.exports = function() {
       });
     });
   }
+
   client.clear = function() {
     collection.drop.apply(collection, arguments);
-  };
+  }
 
   client.getTotalCount = function() {
     collection.count.apply(collection, arguments);
-  };
+  }
 
   client.getSince = function(objId, cbEach, cbDone) {
     client.findWrap({"_id":{"$gt":new db.bson_serializer.ObjectID(objId)}}, {sort:{_id:-1}}, cbEach, cbDone);
@@ -65,7 +65,7 @@ module.exports = function() {
 
   client.getAll = function(fields, callback) {
     collection.find({}, fields, callback);
-  };
+  }
 
   client.getOne = function(id, callback) {
     collection.find({"id":id}, function(error, cursor) {
@@ -75,7 +75,7 @@ module.exports = function() {
         callback(err, doc);
       });
     });
-  };
+  }
 
   client.findWrap = function(query, options, cbEach, cbDone) {
     var cursor = collection.find(query);

--- a/Common/node/collectionDataStore.js
+++ b/Common/node/collectionDataStore.js
@@ -1,0 +1,100 @@
+/*
+*
+* Copyright (C) 2011, The Locker Project
+* All rights reserved.
+*
+* Please see the LICENSE file for more information.
+*
+*/
+var fs = require('fs');
+var lutil = require('lutil');
+
+module.exports = function() {
+  var collection, db, logger;
+  var client = {};
+
+  client.init = function(mongo, collectionName, locker) {
+    collection = mongo.collections[collectionName];
+    collection.ensureIndex({"id":1},{unique:true},function() {});
+    db = mongo.dbClient;
+    logger = require("logger");
+  }
+
+  client.state = function(callback) {
+    client.getTotalCount(function(err, countInfo) {
+      if(err) return callback(err);
+      client.getLastObjectID(function(err, lastObject) {
+        if(err) return callback(err);
+        var objId = '000000000000000000000000';
+        if (lastObject) objId = lastObject._id.toHexString();
+        var updated = Date.now();
+        try {
+          var js = JSON.parse(path.join(lockerInfo.workingDirectory, fs.readFileSync('state.json')));
+          if(js && js.updated) updated = js.updated;
+        } catch(E) {}
+        return callback(undefined, {ready:1, count:countInfo, updated:updated, lastId:objId});
+      });
+    });
+  }
+  client.clear = function() {
+    collection.drop.apply(collection, arguments);
+  };
+
+  client.getTotalCount = function() {
+    collection.count.apply(collection, arguments);
+  };
+
+  client.getSince = function(objId, cbEach, cbDone) {
+    client.findWrap({"_id":{"$gt":new db.bson_serializer.ObjectID(objId)}}, {sort:{_id:-1}}, cbEach, cbDone);
+  }
+
+  client.getLastObjectID = function(cbDone) {
+    collection.find({}, {fields:{_id:1}, limit:1, sort:{_id:-1}}).nextObject(cbDone);
+  }
+
+  client.get = function(id, callback) {
+    var or = []
+    try {
+      or.push({_id:new db.bson_serializer.ObjectID(id)});
+    } catch(E) {
+      // might be the regular id, not _id, in which case
+    }
+    or.push({id:id});
+    collection.findOne({$or:or}, callback);
+  }
+
+  client.getAll = function(fields, callback) {
+    collection.find({}, fields, callback);
+  };
+
+  client.getOne = function(id, callback) {
+    collection.find({"id":id}, function(error, cursor) {
+      if (error) return callback(error, cursor);
+      cursor.nextObject(function(err, doc) {
+        if (err) return callback(err);
+        callback(err, doc);
+      });
+    });
+  };
+
+  client.findWrap = function(query, options, cbEach, cbDone) {
+    var cursor = collection.find(query);
+    if (options.sort) cursor.sort(options.sort);
+    if (options.limit) cursor.limit(options.limit);
+    cursor.each(function(err, item) {
+      if (item === null) return cbDone();
+      cbEach(item);
+    });
+  }
+
+  var writeTimer = false;
+  client.updateState = function() {
+    if (writeTimer) clearTimeout(writeTimer);
+    writeTimer = setTimeout(function() {
+      lutil.atomicWriteFileSync("state.json", JSON.stringify({updated:Date.now()}));
+    }, 5000);
+  }
+
+  return client;
+}
+

--- a/Common/node/collectionDataStore.js
+++ b/Common/node/collectionDataStore.js
@@ -78,9 +78,10 @@ module.exports = function() {
   }
 
   client.findWrap = function(query, options, cbEach, cbDone) {
-    var cursor = collection.find(query);
+    var cursor = (options.fields) ? collection.find(query, options) : collection.find(query);
     if (options.sort) cursor.sort(options.sort);
     if (options.limit) cursor.limit(options.limit);
+    if (options.offset) cursor.skip(options.offset);
     cursor.each(function(err, item) {
       if (item === null) return cbDone();
       cbEach(item);

--- a/Common/node/collectionDataStore.js
+++ b/Common/node/collectionDataStore.js
@@ -15,7 +15,7 @@ module.exports = function() {
 
   client.init = function(mongo, collectionName, locker) {
     collection = mongo.collections[collectionName];
-    collection.ensureIndex({"id":1},{unique:true},function() {});
+    // collection.ensureIndex({"id":1},{unique:true},function() {});
     db = mongo.dbClient;
   }
 

--- a/Common/node/lconfig.js
+++ b/Common/node/lconfig.js
@@ -84,7 +84,7 @@ exports.load = function(filepath) {
     };
 //    exports.ui = config.ui || 'dashboardv3:Apps/dashboardv3';
     exports.ui = config.ui || 'dashboardv3:Apps/dashboardv3';
-    exports.quiesce = config.quiesce || 650000;
+    exports.quiesce = (config.quiesce || 650) * 1000;
 
     config.dashboard = config.dashboard || {};
     config.dashboard.lockerName = config.dashboard.customLockerName || 'locker';

--- a/Common/node/levents.js
+++ b/Common/node/levents.js
@@ -114,7 +114,7 @@ function lqueue(lurl)
         logger.verbose(lqueues[lurl].length()+": sending "+curEvent.action+" event "+curEvent.idr+" to " + lurl);
         request(httpOpts, function(err, res, body) {
             if (err || res.statusCode != 200) {
-                logger.error("There was an error sending " + curEvent.idr + " " + curEvent.action + " to " + lurl + " got " + (err || res.statusCode));
+                logger.error("There was an error sending " + curEvent.idr + " " + curEvent.action + " to " + lurl + " got " + (err || res.statusCode) + ', ' + JSON.stringify(body));
                 logger.verbose(JSON.stringify(curEvent.data));
                 //logger.verbose(body);
                 // TODO: Need to evaluate the logic here, to see if we should retry or other options.

--- a/Common/node/lservicemanager.js
+++ b/Common/node/lservicemanager.js
@@ -480,15 +480,14 @@ function checkForShutdown() {
 
 exports.getCollectionApis = function() {
   var collectionApis = {};
-  for(var i in serviceMap) {
-    if(serviceMap[i].type === 'collection') {
-      try {
+  for (var i in serviceMap) {
+    if (serviceMap[i].type === 'collection') {
+      var modulePath = path.join(__dirname, '..', '..', serviceMap[i].srcdir, 'api.js');
+      if (path.existsSync(modulePath)) {
         collectionApis[i] = {
-          api: require(path.join(__dirname, '..', '..', serviceMap[i].srcdir, 'api.js')),
+          api: require(modulePath),
           lockerInfo: getProcessInformation(serviceMap[i])
         };
-      } catch(err) {
-        console.error("DEBUG: err", err);
       }
     }
   }

--- a/Common/node/lservicemanager.js
+++ b/Common/node/lservicemanager.js
@@ -482,7 +482,7 @@ exports.getCollectionApis = function() {
   var collectionApis = {};
   for (var i in serviceMap) {
     if (serviceMap[i].type === 'collection') {
-      var modulePath = path.join(__dirname, '..', '..', serviceMap[i].srcdir, 'api.js');
+      var modulePath = path.join(lconfig.lockerDir, serviceMap[i].srcdir, 'api.js');
       if (path.existsSync(modulePath)) {
         collectionApis[i] = {
           api: require(modulePath),

--- a/Ops/webservice.js
+++ b/Ops/webservice.js
@@ -205,12 +205,13 @@ locker.get('/core/:svcId/at', function(req, res) {
 
 var collectionApis = serviceManager.getCollectionApis();
 for(var i in collectionApis) {
-  var oldGet = locker.get;
+  locker._oldGet = locker.get;
   locker.get = function(path, callback) {
-    oldGet('/Me/' + i + path, callback);
+    return locker._oldGet('/Me/' + i + path, callback);
   }
   collectionApis[i].api(locker, collectionApis[i].lockerInfo);
-  locker.get = oldGet;
+  locker.get = locker._oldGet;
+  locker._oldGet = undefined;
 }
 
 // ME PROXY

--- a/Ops/webservice.js
+++ b/Ops/webservice.js
@@ -28,7 +28,6 @@ var lpquery = require("lpquery");
 var lconfig = require("lconfig");
 var logger = require('logger');
 var async = require('async');
-// require('express-namespace');
 
 var lcrypto = require("lcrypto");
 

--- a/Ops/webservice.js
+++ b/Ops/webservice.js
@@ -28,6 +28,7 @@ var lpquery = require("lpquery");
 var lconfig = require("lconfig");
 var logger = require('logger');
 var async = require('async');
+// require('express-namespace');
 
 var lcrypto = require("lcrypto");
 
@@ -201,6 +202,16 @@ locker.get('/core/:svcId/at', function(req, res) {
     logger.info("scheduled "+ svcId + " " + cb + "  at " + at);
     res.end("true");
 });
+
+var collectionApis = serviceManager.getCollectionApis();
+for(var i in collectionApis) {
+  var oldGet = locker.get;
+  locker.get = function(path, callback) {
+    oldGet('/Me/' + i + path, callback);
+  }
+  collectionApis[i].api(locker, collectionApis[i].lockerInfo);
+  locker.get = oldGet;
+}
 
 // ME PROXY
 // all of the requests to something installed (proxy them, moar future-safe)

--- a/_lockerd.js
+++ b/_lockerd.js
@@ -136,13 +136,14 @@ function finishStartup() {
     });
 
     pushManager.init();
-    var webservice = require(__dirname + "/Ops/webservice.js");
+
     // ordering sensitive, as synclet manager is inert during init, servicemanager's init will call into syncletmanager
     syncManager.init(serviceManager, function() {
         registry.init(serviceManager, syncManager, lconfig, lcrypto, function() {
             serviceManager.init(syncManager, registry, function() {  // this may trigger synclets to start!
                 runMigrations("postServices", function() {
                     // start web server (so we can all start talking)
+                    var webservice = require(__dirname + "/Ops/webservice.js");
                     webservice.startService(lconfig.lockerPort, lconfig.lockerListenIP, function(locker) {
                         registry.app(locker); // add it's endpoints
                         postStartup();


### PR DESCRIPTION
The collections can now (optionally) expose an api.js file in their src dir and it will be required in by core and add it's endpoints (GET only right now). This is intended to enable collection processes to turn themselves off more often (only need to run for data processing) and (hopefully) enabled better process priority control (nice down processing, while leaving core at normal priority).

This also add Common/node/collectionDataStore, which abstracts several common data store patterns in collections. Next step is to make some of the API methods common, but I'd rather merge (and deploy) this first.

This passes all tests, but they're aren't really a ton of collection tests. I'd be happy to write more, but if we are moving away from vows it feels like a waste (tell me I'm wrong!). I did auth all connectors to ensure data processing works properly and hit all API endpoints to make sure they work.
