### PR TITLE
Flickr Synclet Updates

### DIFF
--- a/Common/node/lsyncmanager.js
+++ b/Common/node/lsyncmanager.js
@@ -162,7 +162,7 @@ exports.scheduleRun = function(info, synclet) {
         force = true;
         delete info.config.nextRun;
         logger.verbose("scheduling "+key+" to run immediately (paging)");
-        return process.nextTick(run);
+        return setTimeout(run, 2000);
     }
 
     // validation check

--- a/Connectors/Flickr/contacts.js
+++ b/Connectors/Flickr/contacts.js
@@ -7,13 +7,15 @@
 *
 */
 
-var paging = require('./lib/paging');
+var path = require("path");
 
 var PER_PAGE = 1000;
 exports.sync = function(processInfo, callback) {
-    paging.getPage(processInfo, 'flickr.contacts.getList', 'contact', PER_PAGE, {}, function(config, contactsArray) {
-        for(var i in contactsArray)
-            contactsArray[i] = {obj:contactsArray[i], timestamp:config.lastUpdate, type:'new'};
-        callback(null, {config: config, data: {contact:contactsArray}});
-    });
+  var paging = require(path.join(processInfo.absoluteSrcdir, 'lib', 'paging.js'));
+  paging.getPage(processInfo, 'flickr.contacts.getList', 'contact', PER_PAGE, {}, function(config, contactsArray) {
+    for(var i in contactsArray) {
+      contactsArray[i] = {obj:contactsArray[i], timestamp:config.lastUpdate, type:'new'};
+    }
+    callback(null, {config: config, data: {contact:contactsArray}});
+  });
 }

--- a/Connectors/Flickr/lib/paging.js
+++ b/Connectors/Flickr/lib/paging.js
@@ -4,7 +4,7 @@ exports.getPage = function(processInfo, endpoint, type, perPage, params, callbac
     var config = processInfo.config || {};
     var auth = processInfo.auth;
     var client = new Flickr(auth.apiKey, auth.apiSecret);
-    config.paging = config.paging || {};
+    config.paging = config.paging || {totalPages:-1};
     if(!config.paging.lastPage)
         config.paging.lastPage = 0;
     var thisPage = config.paging.lastPage + 1;
@@ -26,13 +26,16 @@ exports.getPage = function(processInfo, endpoint, type, perPage, params, callbac
             if(page > pages) { //whoa whoa whoa, bad news bears, page should never be greater than pages
                 // seems like there is a possiblity of pages === 0 if there are no photos
                 config.paging.lastPage = 0;
+                config.paging.totalPages = -1;
                 config.nextRun = 0;
-                console.error('Flickr error, page > total pages: page ==', json[type_s].page, ', pages ==', json[type_s].pages);
+                if (pages != 0) console.error('Flickr error, page > total pages: page ==', json[type_s].page, ', pages ==', json[type_s].pages);
             } else if(page === pages) { // last page
                 config.paging.lastPage = 0;
+                config.paging.totalPages = -1;
                 config.nextRun = 0;
             } else { // still paging
                 config.paging.lastPage = page;
+                config.paging.totalPages = pages;
                 config.nextRun = -1;
             }
             callback(config, json[type_s][type]);

--- a/Connectors/Flickr/synclets.json
+++ b/Connectors/Flickr/synclets.json
@@ -3,6 +3,7 @@
     "mongoId" : {
         "contacts":"nsid"
     },
+    "vm":true,
     "synclets":[{"name":"contacts", "frequency":3600},
                 {"name":"photos", "frequency": 3600}]
 }


### PR DESCRIPTION
This is a shortest path attempt to clean up the flickr synclet from it's previous full scan state.  It now uses the upload time to decide what's new and upped the per page batch size to 500.
