### PR TITLE
Adding the Zeo connector (with 1 synclet: sleep)

### DIFF
--- a/Connectors/Zeo/auth.js
+++ b/Connectors/Zeo/auth.js
@@ -1,0 +1,22 @@
+module.exports = {
+  handler: function (host, apiKeys, done, req, res) {
+    if (req.method === 'POST') {
+      done(null, {
+        appKey: apiKeys.appKey,
+        username: req.body.username,
+        password: req.body.password
+      });
+
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+
+    res.end('Please enter your Zeo credentials:' +
+      '<form method="post">' +
+        '<p><label>Username: <input name="username" type="textbox" size="32" /></label></p>' +
+        '<p><label>Password: <input name="password" type="password" size="32" /></label></p>' +
+        '<input type="submit" value="Save!">' +
+      '</form>');
+  }
+};

--- a/Connectors/Zeo/lib.js
+++ b/Connectors/Zeo/lib.js
@@ -1,0 +1,62 @@
+exports.callApi = function(pi, cb, pather, querier, arrayer) {
+  var https = require('https');
+
+  var authorization = 'Basic ' + new Buffer(pi.auth.username + ':' +
+    pi.auth.password).toString('base64');
+
+  var options = {
+    host: 'api.myzeo.com',
+    port: 8443,
+    path: '/zeows/api/v1/json' + pather(pi) + querier(pi),
+    headers: {
+      'Accept': '*/*',
+      'Connection': 'close',
+      'Referer': pi.uri,
+      'Authorization': authorization
+    }
+  };
+
+  // Send the request
+  https.get(options, function(res) {
+    res.setEncoding('utf8');
+
+    var data = '';
+
+    res.on('data', function(chunk) {
+      data += chunk;
+    });
+
+    // Once we've got the full response...
+    res.on('end', function() {
+      cb(data);
+    });
+  });
+};
+
+exports.genericSync = function(type, pather, querier, arrayer) {
+  return function(pi, cb) {
+    exports.callApi(pi, function(data) {
+      var js;
+
+      try {
+        js = JSON.parse(data);
+      } catch(E) {
+        return cb(err);
+      }
+
+      arrayer(pi, js, function(arrayData) {
+        var array = {};
+
+        array[type] = arrayData;
+
+        // And return it using the passed in callback,
+        // with (optionally) updated auth and config data
+        cb(null, {
+          auth: pi.auth,
+          config: pi.config,
+          data: array
+        });
+      });
+    }, pather, querier, arrayer);
+  };
+};

--- a/Connectors/Zeo/package.json
+++ b/Connectors/Zeo/package.json
@@ -1,0 +1,21 @@
+{
+  "author": "Beau Gunderson <beau@beaugunderson.com>",
+  "name": "zeo",
+  "description": "Zeo",
+  "version": "0.1.2",
+  "repository": {
+    "title": "Zeo",
+    "handle": "zeo",
+    "author": "Beau Gunderson <beau@beaugunderson.com>",
+    "update": "auto",
+    "github": "https://github.com/LockerProject/Locker",
+    "type": "connector",
+    "static": "false",
+    "url": ""
+  },
+  "engines": {
+    "node": ">=0.4.9"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/Connectors/Zeo/sleep.js
+++ b/Connectors/Zeo/sleep.js
@@ -1,0 +1,47 @@
+var async = require('async'),
+    lib = require('./lib');
+
+exports.sync = lib.genericSync('sleep', function(pi) {
+  return '/sleeperService/getAllDatesWithSleepData';
+}, function(pi) {
+  return '?key=' + pi.auth.appKey;
+}, function(pi, js, cb) {
+  var dates = js.response.dateList.date;
+
+  if (!js || !dates) {
+    return [];
+  }
+
+  // For each date with a sleep record...
+  async.mapSeries(dates, function(date, mapped) {
+    // Retrieve the record...
+    lib.callApi(pi, function(data) {
+      var js;
+
+      try {
+        js = JSON.parse(data);
+      } catch(E) {
+        mapped(E);
+      }
+
+      var record = js.response.sleepRecord;
+
+      if (!js || !record) {
+        mapped();
+      }
+
+      record.id = record.startDate.year + '-' +
+        record.startDate.month + '-' +
+        record.startDate.day;
+
+      mapped(null, record);
+    }, function(pi) {
+      return '/sleeperService/getSleepRecordForDate';
+    }, function(pi) {
+      return '?key=' + pi.auth.appKey + '&date=' + date.year + '-' + date.month + '-' + date.day;
+    });
+  }, function(err, results){
+    // And return them all up the chain.
+    cb(results);
+  });
+});

--- a/Connectors/Zeo/synclets.json
+++ b/Connectors/Zeo/synclets.json
@@ -1,0 +1,5 @@
+{
+  "synclets": [
+    { "name": "sleep", "frequency": 86400, "threshold": 0 }
+  ]
+}

--- a/Connectors/Zeo/test.js
+++ b/Connectors/Zeo/test.js
@@ -1,0 +1,10 @@
+var fs = require('fs');
+var pi = JSON.parse(fs.readFileSync("../../Me/zeo/me.json"));
+
+var sync = require(process.argv[2]);
+
+sync.sync(pi, function(e, js) {
+  console.error('error', e);
+
+  console.error("got js", JSON.stringify(js));
+});

--- a/Ops/registry.js
+++ b/Ops/registry.js
@@ -91,6 +91,7 @@ exports.app = function (app) {
 
     app.get('/auth/:id', authIsAwesome);
     app.get('/auth/:id/auth', authIsAuth);
+    app.post('/auth/:id/auth', express.bodyParser(), authIsAuth);
 
     app.get('/deauth/:id', deauthIsAwesomer);
 };


### PR DESCRIPTION
Also includes a change to registry.js to allow POSTs to /auth/:id/auth (so that passwords can be sent as POST data and not via the querystring).

I have an implementation question about this: is it better to break up long-running synclets (longer than 30 seconds) to a pattern that relies on external pagination and multiple runs of the synclet to retrieve all of the data?

Right now I'm handling pagination inside of the synclet and it takes a while to run on my dataset (around a minute for ~134 HTTP gets, though I plan to make it smarter for subsequent runs).

[Zeo API keys available here](http://mysleep.myzeo.com/api/signup.php).
